### PR TITLE
fix(docker): use multistage docker to keep image clean and smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,43 @@
+# builder
+FROM python:3.11-slim AS builder
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set working directory
+WORKDIR /app
+
+COPY requirements.txt .
+
+# Install tools needed for building
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    iputils-ping \
+    nut-client \
+    net-tools \
+    gcc \
+    libffi-dev \
+    build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+COPY . .
+
+RUN python -m compileall -q .
+
+# runner
 FROM python:3.11-slim
 
 # Set working directory
 WORKDIR /app
 
-# Copy project files
-COPY . /app
+# Copy installed Python packages from builder
+COPY --from=builder /install /usr/local
 
-# Install system tools
-RUN apt-get update && apt-get install -y \
-    iputils-ping \
-    nut-client \
-    net-tools \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Copy precompiled app code
+COPY --from=builder /app /app
 
 # Set correct PYTHONPATH
 ENV PYTHONPATH=/app


### PR DESCRIPTION
This is awesome!  Love it!

This PR is only a recommendation and an optimization, none of this is required.  There isn't anything wrong with your current docker file however I have separated some of the stages of the image build.

* `ENV DEBIAN_FRONTEND=noninteractive` will avoid any prompts (not needed but good to have in case you add dependencies in the future that could prompt).
* uses `FROM python:3.11-slim AS builder` as a build stage.   We really only need the output from this stage and the build tools aren't required to run the production image.
* `FROM python:3.11-slim` uses a fresh slim image and `COPY --from=builder /app /app` copies the output to it

This results in a smaller image ( `242.77 MB` vs `273.95 MB`) with a faster startup, less dependencies, and less bloat over time.

This is totally just a recommendation, so feel free to close this or use what you need!