### PR TITLE
Add optional Apprise notification logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This helps reboot systems automatically after a controlled shutdown caused by a 
 - Supports NUT with or without authentication
 - Persistent state file for post-reboot recovery
 - Runs as a standalone Python service or Docker container
+- Supports external notifications via [Apprise](https://github.com/caronc/apprise/wiki) URLs
 
 ---
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,7 +1,7 @@
 # copy this to config.yaml before running wolnut
 log_level: INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 apprise_urls: # URLs for Apprise notifications: https://github.com/caronc/apprise/wiki
-  - "discord://webhook_id/webhook_token"
+  - "" # e.g. discord://webhook_id/webhook_token
 
 nut:
   ups: "ups@localhost"        # Format: <ups-name>@<host>

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,5 +1,7 @@
-# copy this to config.yaml befor running wolnut
+# copy this to config.yaml before running wolnut
 log_level: INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+apprise_urls: # URLs for Apprise notifications: https://github.com/caronc/apprise/wiki
+  - "discord://webhook_id/webhook_token"
 
 nut:
   ups: "ups@localhost"        # Format: <ups-name>@<host>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pygments==2.19.1
 pytest==8.4.0
 PyYAML==6.0.2
 wakeonlan==3.1.0
+apprise==1.4.0

--- a/wolnut/__init__.py
+++ b/wolnut/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logging.basicConfig(
     level=logging.INFO,

--- a/wolnut/__init__.py
+++ b/wolnut/__init__.py
@@ -1,7 +1,10 @@
 import logging
+from wolnut.apprise import apprise_notifier
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 logger = logging.getLogger("wolnut")
+
+notifier = apprise_notifier("wolnut")

--- a/wolnut/apprise.py
+++ b/wolnut/apprise.py
@@ -1,0 +1,121 @@
+import apprise
+import logging
+
+logger = logging.getLogger("wolnut")
+apprise_instance = {}
+
+class apprise_notifier:
+    def __init__(self, name: str = "apprise") -> None:
+        """ Initializes the Apprise notifier using the provided name or retrieves an existing instance.
+
+        Args:
+            name (str, optional): Name of the Apprise instance. Defaults to "apprise".
+        """
+        if name in apprise_instance:
+            self._apprise_instance = apprise_instance[name]
+            return
+        self._apprise_instance = apprise.Apprise()
+        apprise_instance[name] = self._apprise_instance
+        
+    def _apprise_notify( self, body: str, notify_level: int, title: str) -> None:
+        """
+        Sends a notification using the Apprise instance.
+
+        Args:
+            body (str): Body of the notification.
+            notify_type (int): Notification Level.
+            title (str): Title of the notification.
+        """
+        if not self._apprise_instance:
+            logging.debug("Apprise instance is not initialized. Cannot send notification.")
+            return
+        
+        if notify_level < logger.getEffectiveLevel():
+            return
+        
+        match notify_level:
+            case logging.DEBUG:
+                notify_type = apprise.NotifyType.INFO
+            case logging.INFO:
+                notify_type = apprise.NotifyType.INFO
+            case logging.WARNING:
+                notify_type = apprise.NotifyType.WARNING
+            case logging.ERROR:
+                notify_type = apprise.NotifyType.FAILURE
+            case _:
+                notify_type = apprise.NotifyType.INFO
+        
+        try:
+            response = self._apprise_instance.notify(
+                body=body,
+                notify_type=notify_type,
+                title=title,
+            )
+            if response:
+                logging.info("Notification sent successfully: %s", title)
+            else:
+                logging.error("Failed to send notification: %s", title)
+        except Exception as e:
+            logging.error("Error sending notification: %s", e)
+
+    def debug(self, body: str, *args:object, title: str = "WOLNUT Debug") -> None:
+        """
+        Sends a debug notification.
+        Args:
+            body (str): Body of the notification.
+            title (str, optional): Title of the notification. Defaults to "WOLNUT Debug".
+        """
+        logger.debug(body, args)
+        self._apprise_notify(body.format(args), logging.DEBUG, title)
+
+    def info(self, body: str, *args:object,  title: str = f"WOLNUT Notification") -> None:
+        """
+        Sends an informational notification.
+
+        Args:
+            body (str): Body of the notification.
+            title (str, optional): Title of the notification. Defaults to "WOLNUT Notification".
+        """
+        logger.info(body, args)
+        self._apprise_notify(body.format(args), logging.INFO, title)
+        
+    def warning(self, body: str, *args:object,  title: str = "WOLNUT Warning") -> None:
+        """
+        Sends a warning notification.
+        Args:
+            body (str): Body of the notification.
+            title (str, optional): Title of the notification. Defaults to "WOLNUT Warning".
+        """
+        logger.warning(body, args)
+        self._apprise_notify(body.format(args), logging.WARNING, title)
+        
+    def error(self, body: str, *args:object, title: str = "WOLNUT Error") -> None:
+        """
+        Sends an error notification.
+        Args:
+            body (str): Body of the notification.
+            title (str, optional): Title of the notification. Defaults to "WOLNUT Error".
+        """
+        logger.error(body, args)
+        self._apprise_notify(body.format(args), logging.ERROR, title)
+        
+    def addUrls(self, urls: list[str]) -> None:
+        """
+        Adds notification URLs to the Apprise instance.
+
+        Args:
+            urls (list[str]): List of Apprise URLs to add.
+        """
+        if not urls:
+            logging.debug("No Apprise URLs provided. Skipping addition.")
+            return
+        self._apprise_instance.add(urls)
+        
+    def setLevel(self, level: logging._Level) -> None:
+        """
+        Sets the logging level for the Apprise notifier.
+
+        Args:
+            level (int): Logging level to set.
+        """
+        logger.setLevel(level)

--- a/wolnut/apprise.py
+++ b/wolnut/apprise.py
@@ -111,7 +111,7 @@ class apprise_notifier:
             return
         self._apprise_instance.add(urls)
         
-    def setLevel(self, level: logging._Level) -> None:
+    def setLevel(self, level: int | str) -> None:
         """
         Sets the logging level for the Apprise notifier.
 

--- a/wolnut/apprise_logging.py
+++ b/wolnut/apprise_logging.py
@@ -27,7 +27,7 @@ class apprise_notifier:
             title (str): Title of the notification.
         """
         if not self._apprise_instance:
-            logging.debug("Apprise instance is not initialized. Cannot send notification.")
+            logger.debug("Apprise instance is not initialized. Cannot send notification.")
             return
         
         if notify_level < logger.getEffectiveLevel():
@@ -52,11 +52,11 @@ class apprise_notifier:
                 title=title,
             )
             if response:
-                logging.info("Notification sent successfully: %s", title)
+                logger.info("Notification sent successfully: %s", title)
             else:
-                logging.error("Failed to send notification: %s", title)
+                logger.error("Failed to send notification: %s", title)
         except Exception as e:
-            logging.error("Error sending notification: %s", e)
+            logger.error("Error sending notification: %s", e)
 
     def debug(self, body: str,  title: str = "WOLNUT Debug") -> None:
         """
@@ -107,7 +107,7 @@ class apprise_notifier:
             urls (list[str]): List of Apprise URLs to add.
         """
         if not urls:
-            logging.debug("No Apprise URLs provided. Skipping addition.")
+            logger.debug("No Apprise URLs provided. Skipping addition.")
             return
         self._apprise_instance.add(urls)
         

--- a/wolnut/apprise_logging.py
+++ b/wolnut/apprise_logging.py
@@ -58,17 +58,17 @@ class apprise_notifier:
         except Exception as e:
             logging.error("Error sending notification: %s", e)
 
-    def debug(self, body: str, *args:object, title: str = "WOLNUT Debug") -> None:
+    def debug(self, body: str,  title: str = "WOLNUT Debug") -> None:
         """
         Sends a debug notification.
         Args:
             body (str): Body of the notification.
             title (str, optional): Title of the notification. Defaults to "WOLNUT Debug".
         """
-        logger.debug(body, args)
-        self._apprise_notify(body.format(args), logging.DEBUG, title)
+        logger.debug(body)
+        self._apprise_notify(body, logging.DEBUG, title)
 
-    def info(self, body: str, *args:object,  title: str = f"WOLNUT Notification") -> None:
+    def info(self, body: str,   title: str = f"WOLNUT Notification") -> None:
         """
         Sends an informational notification.
 
@@ -76,28 +76,28 @@ class apprise_notifier:
             body (str): Body of the notification.
             title (str, optional): Title of the notification. Defaults to "WOLNUT Notification".
         """
-        logger.info(body, args)
-        self._apprise_notify(body.format(args), logging.INFO, title)
+        logger.info(body)
+        self._apprise_notify(body, logging.INFO, title)
         
-    def warning(self, body: str, *args:object,  title: str = "WOLNUT Warning") -> None:
+    def warning(self, body: str, title: str = "WOLNUT Warning") -> None:
         """
         Sends a warning notification.
         Args:
             body (str): Body of the notification.
             title (str, optional): Title of the notification. Defaults to "WOLNUT Warning".
         """
-        logger.warning(body, args)
-        self._apprise_notify(body.format(args), logging.WARNING, title)
+        logger.warning(body)
+        self._apprise_notify(body, logging.WARNING, title)
         
-    def error(self, body: str, *args:object, title: str = "WOLNUT Error") -> None:
+    def error(self, body: str, title: str = "WOLNUT Error") -> None:
         """
         Sends an error notification.
         Args:
             body (str): Body of the notification.
             title (str, optional): Title of the notification. Defaults to "WOLNUT Error".
         """
-        logger.error(body, args)
-        self._apprise_notify(body.format(args), logging.ERROR, title)
+        logger.error(body)
+        self._apprise_notify(body, logging.ERROR, title)
         
     def addUrls(self, urls: list[str]) -> None:
         """

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -5,7 +5,7 @@ import os
 import sys
 import apprise
 from wolnut.utils import validate_mac_format, resolve_mac_from_host
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logger = apprise_notifier("wolnut")
 
@@ -95,11 +95,11 @@ def load_config(path: str | None = None) -> WolnutConfig:
         wake_on=wake_on,
         clients=clients,
         log_level=raw.get("log_level", "INFO").upper(),
-        apprise_urls=raw.get("apprise_url", None)
+        apprise_urls=raw.get("apprise_urls", None)
     )
     logger.info("Config Imported Successfully")
 
-    if wolnut_config.apprise_urls:
+    if not wolnut_config.apprise_urls is None:
         logger.addUrls(wolnut_config.apprise_urls)
         logger.info("Apprise notifications enabled with URLs: %s",
                      wolnut_config.apprise_urls)

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -56,10 +56,10 @@ def load_config(path: str | None = None) -> WolnutConfig:
             raw = yaml.safe_load(f)
         validate_config(raw)
     except FileNotFoundError:
-        logger.error("Config file not found at '%s'.", path)
+        logger.error(f"Config file not found at '{path}'.")
         sys.exit(1)
     except Exception as e:
-        logger.error("Failed to load or parse config file: %s", e)
+        logger.error(f"Failed to load or parse config file: {e}")
         sys.exit(1)
 
     # LOGGING...
@@ -75,19 +75,17 @@ def load_config(path: str | None = None) -> WolnutConfig:
         try:
             mac = raw_client["mac"]
             if mac == "auto":
-                logger.info("Resolving MAC for %s at %s...",
-                            raw_client['name'], raw_client['host'])
+                logger.info(f"Resolving MAC for {raw_client['name']} at {raw_client['host']}...")
                 resolved_mac = resolve_mac_from_host(raw_client["host"])
                 if not resolved_mac:
                     raise ValueError(
                         f"Could not resolve MAC address for {raw_client['name']} ({raw_client['host']})")
                 raw_client["mac"] = resolved_mac
-                logger.info("MAC for %s: %s", raw_client['name'], resolved_mac)
+                logger.info(f"MAC for {raw_client['name']}: {resolved_mac}")
 
             clients.append(ClientConfig(**raw_client))
         except ValueError as e:
-            logger.error("Failed to load client %s: %s",
-                         raw_client.get("name", "?"), e)
+            logger.error(f"Failed to load client {raw_client.get('name', '?')}: {e}")
 
     wolnut_config = WolnutConfig(
         nut=nut,
@@ -101,12 +99,11 @@ def load_config(path: str | None = None) -> WolnutConfig:
 
     if not wolnut_config.apprise_urls is None:
         logger.addUrls(wolnut_config.apprise_urls)
-        logger.info("Apprise notifications enabled with URLs: %s",
-                     wolnut_config.apprise_urls)
+        logger.info(f"Apprise notifications enabled with URLs: {wolnut_config.apprise_urls}")
 
 
     for client in wolnut_config.clients:
-        logger.info("Client: %s at MAC: %s", client.name, client.mac)
+        logger.info(f"Client: {client.name} at MAC: {client.mac}")
         
 
     return wolnut_config

--- a/wolnut/main.py
+++ b/wolnut/main.py
@@ -4,17 +4,16 @@ from wolnut.config import load_config
 from wolnut.state import ClientStateTracker
 from wolnut.monitor import get_ups_status, is_client_online
 from wolnut.wol import send_wol_packet
+from wolnut.apprise import apprise_notifier
 
-logger = logging.getLogger("wolnut")
+logger = apprise_notifier("wolnut")
 
 
 def main():
     """MAIN LOOP"""
     config = load_config()
-
     logger.setLevel(config.log_level)
     logger.info("WOLNUT started. Monitoring UPS: %s", config.nut.ups)
-
     on_battery = False
     recorded_down_clients = set()
     recorded_up_clients = set()

--- a/wolnut/main.py
+++ b/wolnut/main.py
@@ -4,7 +4,7 @@ from wolnut.config import load_config
 from wolnut.state import ClientStateTracker
 from wolnut.monitor import get_ups_status, is_client_online
 from wolnut.wol import send_wol_packet
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logger = apprise_notifier("wolnut")
 

--- a/wolnut/monitor.py
+++ b/wolnut/monitor.py
@@ -2,8 +2,9 @@ import subprocess
 import logging
 import platform
 from typing import Optional
+from wolnut.apprise import apprise_notifier
 
-logger = logging.getLogger("wolnut")
+logger = apprise_notifier("wolnut")
 
 
 def get_ups_status(ups_name: str, username: Optional[str] = None, password: Optional[str] = None) -> dict:

--- a/wolnut/monitor.py
+++ b/wolnut/monitor.py
@@ -2,7 +2,7 @@ import subprocess
 import logging
 import platform
 from typing import Optional
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logger = apprise_notifier("wolnut")
 

--- a/wolnut/monitor.py
+++ b/wolnut/monitor.py
@@ -28,7 +28,7 @@ def get_ups_status(ups_name: str, username: Optional[str] = None, password: Opti
         )
 
         if result.returncode != 0:
-            logger.error("upsc returned error: %s", result.stderr.strip())
+            logger.error(f"upsc returned error: {result.stderr.strip()}")
             return {}
 
         status = {}
@@ -40,7 +40,7 @@ def get_ups_status(ups_name: str, username: Optional[str] = None, password: Opti
         return status
 
     except Exception as e:
-        logger.error("Failed to get UPS status: %s", e)
+        logger.error(f"Failed to get UPS status: {e}")
         return {}
 
 
@@ -53,8 +53,8 @@ def is_client_online(host: str) -> bool:
             stderr=subprocess.DEVNULL,
             check=False
         )
-        logger.debug("Host: %s Online: %s", host, result.returncode == 0)
+        logger.debug(f"Host: {host} Online: {result.returncode == 0}")
         return result.returncode == 0
     except Exception as e:
-        logger.warning("Failed to ping %s: %s", host, e)
+        logger.warning(f"Failed to ping {host}: {e}")
         return False

--- a/wolnut/state.py
+++ b/wolnut/state.py
@@ -61,7 +61,7 @@ class ClientStateTracker:
                     self._client_states[name].update(state)
 
         except Exception as e:
-            logger.warning("Failed to load state from file: %s", e)
+            logger.warning(f"Failed to load state from file: {e}")
 
     def _save_state(self):
         save_data = {
@@ -72,7 +72,7 @@ class ClientStateTracker:
             with open(self._state_file, "w") as f:
                 json.dump(save_data, f)
         except Exception as e:
-            logger.warning("Failed to save state to file: %s", e)
+            logger.warning(f"Failed to save state to file: {e}")
 
     def update(self, client_name: str, online: bool):
         if client_name in self._client_states:

--- a/wolnut/state.py
+++ b/wolnut/state.py
@@ -3,8 +3,9 @@ import os
 from typing import Dict, Any
 import logging
 import time
+from wolnut.apprise import apprise_notifier
 
-logger = logging.getLogger("wolnut")
+logger = apprise_notifier("wolnut")
 logger.setLevel(logging.INFO)
 
 

--- a/wolnut/state.py
+++ b/wolnut/state.py
@@ -3,7 +3,7 @@ import os
 from typing import Dict, Any
 import logging
 import time
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logger = apprise_notifier("wolnut")
 logger.setLevel(logging.INFO)

--- a/wolnut/utils.py
+++ b/wolnut/utils.py
@@ -1,8 +1,9 @@
 import subprocess
 import re
 import logging
+from wolnut.apprise import apprise_notifier
 
-logger = logging.getLogger("wolnut")
+logger = apprise_notifier("wolnut")
 
 
 def validate_mac_format(mac: str) -> bool:

--- a/wolnut/utils.py
+++ b/wolnut/utils.py
@@ -36,7 +36,7 @@ def resolve_mac_from_host(host: str) -> str | None:
         subprocess.run(["ping", "-c", "1", host],
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except Exception as e:
-        logger.warning("Failed to ping: %s: %s", host, e)
+        logger.warning(f"Failed to ping: {host}: {e}")
         return None
 
     # Read the ARP table
@@ -48,6 +48,6 @@ def resolve_mac_from_host(host: str) -> str | None:
         if match:
             return match.group(0)
     except Exception as e:
-        logger.warning("Failed to resolve ARP for: %s: %s", host, e)
+        logger.warning(f"Failed to resolve ARP for: {host}: {e}")
 
     return None

--- a/wolnut/utils.py
+++ b/wolnut/utils.py
@@ -1,7 +1,7 @@
 import subprocess
 import re
 import logging
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logger = apprise_notifier("wolnut")
 

--- a/wolnut/wol.py
+++ b/wolnut/wol.py
@@ -16,9 +16,9 @@ def send_wol_packet(mac_address: str, broadcast_ip: str = "255.255.255.255") -> 
         bool: True if the packet was sent successfully, False otherwise.
     """
     try:
-        logger.debug("Sending WOL packet to %s", mac_address)
+        logger.debug(f"Sending WOL packet to {mac_address}")
         send_magic_packet(mac_address, ip_address=broadcast_ip)
         return True
     except Exception as e:
-        logger.error("Failed to send WOL packet to %s: %s", mac_address, e)
+        logger.error(f"Failed to send WOL packet to {mac_address}: {e}")
         return False

--- a/wolnut/wol.py
+++ b/wolnut/wol.py
@@ -1,6 +1,6 @@
 import logging
 from wakeonlan import send_magic_packet
-from wolnut.apprise import apprise_notifier
+from wolnut.apprise_logging import apprise_notifier
 
 logger = apprise_notifier("wolnut")
 

--- a/wolnut/wol.py
+++ b/wolnut/wol.py
@@ -1,7 +1,8 @@
 import logging
 from wakeonlan import send_magic_packet
+from wolnut.apprise import apprise_notifier
 
-logger = logging.getLogger("wolnut")
+logger = apprise_notifier("wolnut")
 
 
 def send_wol_packet(mac_address: str, broadcast_ip: str = "255.255.255.255") -> bool:


### PR DESCRIPTION
This PR adds a wrapper for the logging functions which sends all log messages to external notifications using [Apprise](https://github.com/caronc/apprise) while also keeping the previous logs.

Has been tested locally without a UPS connected, although further testing of all functions might be needed.

## Additions:
- Added support for sending logs using Apprise as well as default logging
- Added new config section for notification URLs

## Changes:
- Changed all log messages to use F-Strings rather than format specifiers for easier support for Apprise as well as code readability

## Example Discord Messages:
![image](https://github.com/user-attachments/assets/d0746561-0ddc-469a-bafe-75fac89a7701)


If someone else knows of a better method of adding support, I would be happy for any adjustments/rewrite.