### PR TITLE
add support armv7

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64, linux/arm64, linux/arm/v7]
     steps:
     - name: 🔧 Set up QEMU
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Add ARMv7 support

This PR adds support for building and running the project on ARMv7 devices (such as Raspberry Pi 2).

The GitHub Actions workflow now includes the linux/arm/v7 platform for multi-architecture Docker builds.

Tested:

Successfully built and ran the image on my Raspberry Pi 2 (ARMv7).

Related to #13.