### PR TITLE
Fix int() call

### DIFF
--- a/wolnut/main.py
+++ b/wolnut/main.py
@@ -7,6 +7,8 @@ from wolnut.wol import send_wol_packet
 
 logger = logging.getLogger("wolnut")
 
+def battery_percent(ups_status):
+    return int(float(ups_status.get("battery.charge", 100)))
 
 def main():
     """MAIN LOOP"""
@@ -30,14 +32,14 @@ def main():
         state_tracker.reset()
 
     ups_status = get_ups_status(config.nut.ups)
-    battery_percent = int(ups_status.get("battery.charge", 100))
+    battery_percent = battery_percent(ups_status)
     power_status = ups_status.get("ups.status", "OL")
     logger.info("UPS power status: %s, Battery: %s%%",
                 power_status, battery_percent)
 
     while True:
         ups_status = get_ups_status(config.nut.ups)
-        battery_percent = int(ups_status.get("battery.charge", 100))
+        battery_percent = battery_percent(ups_status)
         power_status = ups_status.get("ups.status", "OL")
 
         logger.debug("UPS power status: %s, Battery: %s%%",

--- a/wolnut/main.py
+++ b/wolnut/main.py
@@ -7,8 +7,8 @@ from wolnut.wol import send_wol_packet
 
 logger = logging.getLogger("wolnut")
 
-def battery_percent(ups_status):
-    return int(float(ups_status.get("battery.charge", 100)))
+def get_battery_percent(ups_status):
+    return round(float(ups_status.get("battery.charge", 100)))
 
 def main():
     """MAIN LOOP"""
@@ -32,14 +32,14 @@ def main():
         state_tracker.reset()
 
     ups_status = get_ups_status(config.nut.ups)
-    battery_percent = battery_percent(ups_status)
+    battery_percent = get_battery_percent(ups_status)
     power_status = ups_status.get("ups.status", "OL")
     logger.info("UPS power status: %s, Battery: %s%%",
                 power_status, battery_percent)
 
     while True:
         ups_status = get_ups_status(config.nut.ups)
-        battery_percent = battery_percent(ups_status)
+        battery_percent = get_battery_percent(ups_status)
         power_status = ups_status.get("ups.status", "OL")
 
         logger.debug("UPS power status: %s, Battery: %s%%",


### PR DESCRIPTION
Currently I get errors if the `battery.charge` is a floating point string:

```
wolnut  | Traceback (most recent call last):
wolnut  |   File "/app/wolnut/main.py", line 149, in <module>
wolnut  |     main()
wolnut  |   File "/app/wolnut/main.py", line 33, in main
wolnut  |     battery_percent = int(ups_status.get("battery.charge", 100))
wolnut  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wolnut  | ValueError: invalid literal for int() with base 10: '99.70'
```

The `int()` function seems to work for strings that represent ints as well as for floating point numbers, but _not_ for strings that represent floating point numbers.