### PR TITLE
Added minimal unit tests, Actions workflow

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -28,18 +28,18 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           cd tests
-          ./run_tests.sh -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml
+          ./run_tests.sh # -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml
 
       # report detailed coverage in PR comment
-      - name: comment test coverage report on PR
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          pytest-xml-coverage-path: coverage.xml
-          title: missing coverage
-          badge-title: Test Coverage
-          hide-badge: false
-          hide-report: false
-          create-new-comment: false
-          hide-comment: false
-          report-only-changed-files: false
-          remove-link-from-badge: true
+      # - name: comment test coverage report on PR
+      #   uses: MishaKav/pytest-coverage-comment@main
+      #   with:
+      #     pytest-xml-coverage-path: coverage.xml
+      #     title: missing coverage
+      #     badge-title: Test Coverage
+      #     hide-badge: false
+      #     hide-report: false
+      #     create-new-comment: false
+      #     hide-comment: false
+      #     report-only-changed-files: false
+      #     remove-link-from-badge: true

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Run Tests
         run: |
-          cd wolnut
           pip3 install -r requirements.txt
           cd tests
           ./run_tests.sh -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -1,11 +1,8 @@
 name: 🐍 Test application code
 on:
   push:
-  #   branches-ignore:
-  #   - "main"
-  # pull_request:
-  #   branches-ignore:
-  #   - "main"
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test-python:
@@ -35,3 +32,4 @@ jobs:
         if: (!cancelled())
         with:
           files: "tests/pytest.xml"
+          comment_mode: off  # remove to get PR comments on test results. Requires additional repo permissions.

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -28,10 +28,10 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           cd tests
-          ./run_tests.sh -v --junitxml=/tmp/pytest.xml
+          ./run_tests.sh -v --junitxml=pytest.xml
 
       - name: Publish Test Report (for display in workflow UI)
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always() # Publish even if tests fail
         with:
-          files: /tmp/pytest.xml
+          files: "**/*.xml"

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -22,7 +22,8 @@ jobs:
           pip3 install -r requirements.txt
           cd wolnut/
           echo '# Formatting Report' | tee -a $GITHUB_STEP_SUMMARY
-          black --check . | tee -a $GITHUB_STEP_SUMMARY
+          # 'black' prints to stderr for some reason.
+          black --check *.py 2>&1 | tee -a $GITHUB_STEP_SUMMARY
   test-python:
     name: Run PyTests
     runs-on: ubuntu-24.04

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -1,6 +1,5 @@
 name: 🐍 Test application code
 on:
-  push:  # Don't merge until I've removed this. I'm testing something really quick.
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -28,10 +28,10 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           cd tests
-          ./run_tests.sh -v --junitxml=pytest.xml
+          ./run_tests.sh -v --junitxml=/tmp/pytest.xml
 
       - name: Publish Test Report (for display in workflow UI)
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always() # Publish even if tests fail
         with:
-          files: pytest.xml
+          files: /tmp/pytest.xml

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -1,9 +1,28 @@
 name: 🐍 Test application code
 on:
+  push:  # Don't merge until I've removed this. I'm testing something really quick.
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
+  lint:
+    name: Run PyTests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Lint code
+        continue-on-error: true  # don't block folks just because of code style
+        run: |
+          pip3 install -r requirements.txt
+          cd wolnut/
+          echo '# Formatting Report' | tee -a $GITHUB_STEP_SUMMARY
+          black --check . | tee -a $GITHUB_STEP_SUMMARY
   test-python:
     name: Run PyTests
     runs-on: ubuntu-24.04

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-22.04", "ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -28,18 +28,10 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           cd tests
-          ./run_tests.sh # -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml
+          ./run_tests.sh -v --junitxml=pytest.xml
 
-      # report detailed coverage in PR comment
-      # - name: comment test coverage report on PR
-      #   uses: MishaKav/pytest-coverage-comment@main
-      #   with:
-      #     pytest-xml-coverage-path: coverage.xml
-      #     title: missing coverage
-      #     badge-title: Test Coverage
-      #     hide-badge: false
-      #     hide-report: false
-      #     create-new-comment: false
-      #     hide-comment: false
-      #     report-only-changed-files: false
-      #     remove-link-from-badge: true
+      - name: Publish Test Report (for display in workflow UI)
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always() # Publish even if tests fail
+        with:
+          files: pytest.xml

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -1,0 +1,46 @@
+name: 🐍 Test application code
+on:
+  push:
+  #   branches-ignore:
+  #   - "main"
+  # pull_request:
+  #   branches-ignore:
+  #   - "main"
+
+jobs:
+  test-python:
+    name: Run PyTests
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: ["ubuntu-22.04", "ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Tests
+        run: |
+          cd wolnut
+          pip3 install -r requirements.txt
+          cd tests
+          ./run_tests.sh -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml
+
+      # report detailed coverage in PR comment
+      - name: comment test coverage report on PR
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          title: missing coverage
+          badge-title: Test Coverage
+          hide-badge: false
+          hide-report: false
+          create-new-comment: false
+          hide-comment: false
+          report-only-changed-files: false
+          remove-link-from-badge: true

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -54,4 +54,4 @@ jobs:
           # remove `comment_mode` or toggle to true to get PR comments detailing the test results.
           # The docs suggest that this requires `pull-requests: write` permissions.
           # see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#permissions
-          comment_mode: false
+          comment_mode: off

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -32,6 +32,6 @@ jobs:
 
       - name: Publish Test Report (for display in workflow UI)
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always() # Publish even if tests fail
+        if: (!cancelled())
         with:
-          files: "**/*.xml"
+          files: "tests/pytest.xml"

--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -1,6 +1,5 @@
 name: 🐍 Test application code
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -32,4 +31,7 @@ jobs:
         if: (!cancelled())
         with:
           files: "tests/pytest.xml"
-          comment_mode: off  # remove to get PR comments on test results. Requires additional repo permissions.
+          # remove `comment_mode` or toggle to true to get PR comments detailing the test results.
+          # The docs suggest that this requires `pull-requests: write` permissions.
+          # see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#permissions
+          comment_mode: false

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -8,7 +8,7 @@ on:
     - "main"
 
 jobs:
-  test-docker-build:
+  test:
     name: 🐳 Test docker image
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -8,7 +8,44 @@ on:
     - "main"
 
 jobs:
-  test:
+  test-python:
+    name: 🐍 Run PyTests
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: ["ubuntu-22.04", "ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Tests
+        run: |
+          cd wolnut
+          pip3 install -r requirements.txt
+          cd tests
+          ./run_tests.sh -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml
+
+      # report detailed coverage in PR comment
+      - name: comment test coverage report on PR
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          title: missing coverage
+          badge-title: Test Coverage
+          hide-badge: false
+          hide-report: false
+          create-new-comment: false
+          hide-comment: false
+          report-only-changed-files: false
+          remove-link-from-badge: true
+
+  test-docker-build:
     name: 🐳 Test docker image
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -8,43 +8,6 @@ on:
     - "main"
 
 jobs:
-  test-python:
-    name: 🐍 Run PyTests
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-22.04", "ubuntu-latest"]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run Tests
-        run: |
-          cd wolnut
-          pip3 install -r requirements.txt
-          cd tests
-          ./run_tests.sh -v --cov mapchete --cov-report xml:coverage.xml --cov-report=term-missing:skip-covered --junitxml=pytest.xml
-
-      # report detailed coverage in PR comment
-      - name: comment test coverage report on PR
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          pytest-xml-coverage-path: coverage.xml
-          title: missing coverage
-          badge-title: Test Coverage
-          hide-badge: false
-          hide-report: false
-          create-new-comment: false
-          hide-comment: false
-          report-only-changed-files: false
-          remove-link-from-badge: true
-
   test-docker-build:
     name: 🐳 Test docker image
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config.yaml
 .vscode/
 .vscode/launch.json
 wolnut_state.json
+**/.pytest_cache
 
 # Magic packet test
 mp-test.py

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.yaml
 .vscode/launch.json
 wolnut_state.json
 **/.pytest_cache
+**/pytest.xml
 
 # Magic packet test
 mp-test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ packaging==25.0
 pluggy==1.6.0
 Pygments==2.19.1
 pytest==8.4.0
+pytest-mock==3.14.1
 PyYAML==6.0.2
 wakeonlan==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest==8.4.0
 pytest-mock==3.14.1
 PyYAML==6.0.2
 wakeonlan==3.1.0
+black==25.1.0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,6 +3,9 @@
 # The tests should live alongside this file.
 # Figure out where we are so we can let pytest know where to find the `wolnut` package.
 script_dir=$(cd `dirname $0` && pwd)
+cd "$script_dir"
+echo "Testing from directory: $script_dir"
+ls -lah
 
 # Run tests found in this dir and let pytest know that `wolnut` is at `../`
 pytest -o pythonpath="$script_dir/.." $@

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# The tests should live alongside this file.
+# Figure out where we are so we can let pytest know where to find the `wolnut` package.
+script_dir=$(cd `dirname $0` && pwd)
+
+# Run tests found in this dir and let pytest know that `wolnut` is at `../`
+pytest -o pythonpath="$script_dir/.."

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,10 +3,6 @@
 # The tests should live alongside this file.
 # Figure out where we are so we can let pytest know where to find the `wolnut` package.
 script_dir=$(cd `dirname $0` && pwd)
-cd "$script_dir"
-echo "Testing from directory: $script_dir"
-ls -lah
 
-# Run tests found in this dir and let pytest know that `wolnut` is at `../`
-echo pytest -o pythonpath="$script_dir/.."
-pytest -o pythonpath="$script_dir/.."
+# Run the tests
+pytest -o pythonpath="$script_dir/../wolnut"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,4 +5,4 @@
 script_dir=$(cd `dirname $0` && pwd)
 
 # Run the tests
-pytest -o pythonpath="$script_dir/../wolnut"
+pytest -o pythonpath="$script_dir/../wolnut" $@

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,4 +5,4 @@
 script_dir=$(cd `dirname $0` && pwd)
 
 # Run tests found in this dir and let pytest know that `wolnut` is at `../`
-pytest -o pythonpath="$script_dir/.."
+pytest -o pythonpath="$script_dir/.." $@

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,4 +8,5 @@ echo "Testing from directory: $script_dir"
 ls -lah
 
 # Run tests found in this dir and let pytest know that `wolnut` is at `../`
-pytest -o pythonpath="$script_dir/.." $@
+echo pytest -o pythonpath="$script_dir/.."
+pytest -o pythonpath="$script_dir/.."

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,7 +1,7 @@
 import state
 
-# [ TODO ] - These tests aren't really checking much of anything, and should
-#            just be thought of as a scaffold to write real tests.
+# [ TODO - Issue #24 ] - These tests aren't really checking much of anything, and should
+#                        just be thought of as a scaffold to write real tests.
 
 def test__load_state(mocker):
   mock_path_exists = mocker.patch("state.os.path.exists")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,46 +1,84 @@
 from wolnut import state
 
-def test___init__():
-  pass
+# [ TODO ] - These tests aren't really checking much of anything, and should
+#            just be thought of as a scaffold to write real tests.
 
-def test__load_state():
-  pass
+def test__load_state(mocker):
+  mock_path_exists = mocker.patch("state.os.path.exists")
+  mock_path_exists.return_value = False
 
-def test__save_state():
-  pass
+  s = state.ClientStateTracker([])
+  mock_path_exists.assert_called_once()
+
+def test__save_state(mocker):
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s._save_state()
+  mock_file.assert_called_once()
 
 def test_update(mocker):
-  pass
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s.update('no such client', False)
+  mock_file.assert_called_once()
 
 def test_mark_wol_sent(mocker):
-  pass
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s.mark_wol_sent('no such client')
+  mock_file.assert_called_once()
 
 def test_mark_skip(mocker):
-  pass
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s.mark_skip('no such client')
+  mock_file.assert_called_once()
 
 def test_mark_all_online_clients(mocker):
-  pass
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s.mark_all_online_clients()
+  mock_file.assert_called_once()
 
-def test_is_online(mocker):
-  pass
+def test_is_online():
+  s = state.ClientStateTracker([])
+  assert not s.is_online('no such client')
 
-def test_was_online_before_shutdown(mocker):
-  pass
+def test_was_online_before_shutdown():
+  s = state.ClientStateTracker([])
+  assert not s.was_online_before_shutdown('no such client')
 
-def test_has_been_wol_sent(mocker):
-  pass
+def test_has_been_wol_sent():
+  s = state.ClientStateTracker([])
+  assert not s.has_been_wol_sent('no such client')
 
-def test_should_attempt_wol(mocker):
-  pass
+def test_should_attempt_wol():
+  s = state.ClientStateTracker([])
+  assert s.should_attempt_wol('no such client', 0)
+  assert s.should_attempt_wol('no such client', 100000)
+  assert s.should_attempt_wol('no such client', -5)
 
-def test_should_skip(mocker):
-  pass
+def test_should_skip():
+  s = state.ClientStateTracker([])
+  assert not s.should_skip('no such client')
 
 def test_set_ups_on_battery(mocker):
-  pass
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s.set_ups_on_battery(True, 9001)
+  assert s._meta_state["ups_on_battery"]
+  assert s._meta_state["battery_percent_at_shutdown"] > 9000   # this should _really_ test for equality (`==`) but, its_over_9000.jpeg
+  mock_file.assert_called_once()
 
-def test_was_ups_on_battery(mocker):
-  pass
+def test_was_ups_on_battery():
+  s = state.ClientStateTracker([])
+  assert not s._meta_state["ups_on_battery"]
 
 def test_reset(mocker):
-  pass
+  mock_file = mocker.patch("builtins.open")
+  s = state.ClientStateTracker([])
+  s.reset()
+  for client_state in s._client_states.values():
+    for key in ["was_online_before_battery", "wol_sent", "skip"]:
+      assert not client_state[key]
+  mock_file.assert_called_once()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,46 @@
+from wolnut import state
+
+def test___init__():
+  pass
+
+def test__load_state():
+  pass
+
+def test__save_state():
+  pass
+
+def test_update(mocker):
+  pass
+
+def test_mark_wol_sent(mocker):
+  pass
+
+def test_mark_skip(mocker):
+  pass
+
+def test_mark_all_online_clients(mocker):
+  pass
+
+def test_is_online(mocker):
+  pass
+
+def test_was_online_before_shutdown(mocker):
+  pass
+
+def test_has_been_wol_sent(mocker):
+  pass
+
+def test_should_attempt_wol(mocker):
+  pass
+
+def test_should_skip(mocker):
+  pass
+
+def test_set_ups_on_battery(mocker):
+  pass
+
+def test_was_ups_on_battery(mocker):
+  pass
+
+def test_reset(mocker):
+  pass

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,4 @@
-from wolnut import state
+import state
 
 # [ TODO ] - These tests aren't really checking much of anything, and should
 #            just be thought of as a scaffold to write real tests.

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,82 +3,98 @@ import state
 # [ TODO - Issue #24 ] - These tests aren't really checking much of anything, and should
 #                        just be thought of as a scaffold to write real tests.
 
-def test__load_state(mocker):
-  mock_path_exists = mocker.patch("state.os.path.exists")
-  mock_path_exists.return_value = False
 
-  s = state.ClientStateTracker([])
-  mock_path_exists.assert_called_once()
+def test__load_state(mocker):
+    mock_path_exists = mocker.patch("state.os.path.exists")
+    mock_path_exists.return_value = False
+
+    s = state.ClientStateTracker([])
+    mock_path_exists.assert_called_once()
+
 
 def test__save_state(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s._save_state()
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s._save_state()
+    mock_file.assert_called_once()
+
 
 def test_update(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s.update('no such client', False)
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s.update("no such client", False)
+    mock_file.assert_called_once()
+
 
 def test_mark_wol_sent(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s.mark_wol_sent('no such client')
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s.mark_wol_sent("no such client")
+    mock_file.assert_called_once()
+
 
 def test_mark_skip(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s.mark_skip('no such client')
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s.mark_skip("no such client")
+    mock_file.assert_called_once()
+
 
 def test_mark_all_online_clients(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s.mark_all_online_clients()
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s.mark_all_online_clients()
+    mock_file.assert_called_once()
+
 
 def test_is_online():
-  s = state.ClientStateTracker([])
-  assert not s.is_online('no such client')
+    s = state.ClientStateTracker([])
+    assert not s.is_online("no such client")
+
 
 def test_was_online_before_shutdown():
-  s = state.ClientStateTracker([])
-  assert not s.was_online_before_shutdown('no such client')
+    s = state.ClientStateTracker([])
+    assert not s.was_online_before_shutdown("no such client")
+
 
 def test_has_been_wol_sent():
-  s = state.ClientStateTracker([])
-  assert not s.has_been_wol_sent('no such client')
+    s = state.ClientStateTracker([])
+    assert not s.has_been_wol_sent("no such client")
+
 
 def test_should_attempt_wol():
-  s = state.ClientStateTracker([])
-  assert s.should_attempt_wol('no such client', 0)
-  assert s.should_attempt_wol('no such client', 100000)
-  assert s.should_attempt_wol('no such client', -5)
+    s = state.ClientStateTracker([])
+    assert s.should_attempt_wol("no such client", 0)
+    assert s.should_attempt_wol("no such client", 100000)
+    assert s.should_attempt_wol("no such client", -5)
+
 
 def test_should_skip():
-  s = state.ClientStateTracker([])
-  assert not s.should_skip('no such client')
+    s = state.ClientStateTracker([])
+    assert not s.should_skip("no such client")
+
 
 def test_set_ups_on_battery(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s.set_ups_on_battery(True, 9001)
-  assert s._meta_state["ups_on_battery"]
-  assert s._meta_state["battery_percent_at_shutdown"] > 9000   # this should _really_ test for equality (`==`) but, its_over_9000.jpeg
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s.set_ups_on_battery(True, 9001)
+    assert s._meta_state["ups_on_battery"]
+    assert (
+        s._meta_state["battery_percent_at_shutdown"] > 9000
+    )  # this should _really_ test for equality (`==`) but, its_over_9000.jpeg
+    mock_file.assert_called_once()
+
 
 def test_was_ups_on_battery():
-  s = state.ClientStateTracker([])
-  assert not s._meta_state["ups_on_battery"]
+    s = state.ClientStateTracker([])
+    assert not s._meta_state["ups_on_battery"]
+
 
 def test_reset(mocker):
-  mock_file = mocker.patch("builtins.open")
-  s = state.ClientStateTracker([])
-  s.reset()
-  for client_state in s._client_states.values():
-    for key in ["was_online_before_battery", "wol_sent", "skip"]:
-      assert not client_state[key]
-  mock_file.assert_called_once()
+    mock_file = mocker.patch("builtins.open")
+    s = state.ClientStateTracker([])
+    s.reset()
+    for client_state in s._client_states.values():
+        for key in ["was_online_before_battery", "wol_sent", "skip"]:
+            assert not client_state[key]
+    mock_file.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,22 +1,30 @@
 import utils
 import subprocess
 
-def test_validate_mac_format():
-  valid_mac_address = "de:ad:be:ef:be:ad"
-  invalid_mac_address = "ea:ts:be:ef:be:ad"  # Mmm. Delicious beef bead.
 
-  # `validate_mac_format()` returns a bool, so no need to compare with `==`
-  assert utils.validate_mac_format(valid_mac_address)
-  assert not utils.validate_mac_format(invalid_mac_address)
+def test_validate_mac_format():
+    valid_mac_address = "de:ad:be:ef:be:ad"
+    invalid_mac_address = "ea:ts:be:ef:be:ad"  # Mmm. Delicious beef bead.
+
+    # `validate_mac_format()` returns a bool, so no need to compare with `==`
+    assert utils.validate_mac_format(valid_mac_address)
+    assert not utils.validate_mac_format(invalid_mac_address)
+
 
 def test_resolve_mac_from_host(mocker):
-  # [ TODO - Issue #24 ] - Write tests that assert the appropriate exceptions were raised
-  class MockSubprocessResultOkay(object):
-    stdout = "de:ad:be:ef:be:ad"
+    # [ TODO - Issue #24 ] - Write tests that assert the appropriate exceptions were raised
+    class MockSubprocessResultOkay(object):
+        stdout = "de:ad:be:ef:be:ad"
 
-  mock_subprocess_run = mocker.patch("utils.subprocess.run")
-  mock_subprocess_run.return_value = MockSubprocessResultOkay()
-  result = utils.resolve_mac_from_host('localhost')
-  assert result == MockSubprocessResultOkay.stdout
-  mock_subprocess_run.assert_any_call(["ping", "-c", "1", 'localhost'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-  mock_subprocess_run.assert_any_call(["arp", "-n", 'localhost'], capture_output=True, text=True)
+    mock_subprocess_run = mocker.patch("utils.subprocess.run")
+    mock_subprocess_run.return_value = MockSubprocessResultOkay()
+    result = utils.resolve_mac_from_host("localhost")
+    assert result == MockSubprocessResultOkay.stdout
+    mock_subprocess_run.assert_any_call(
+        ["ping", "-c", "1", "localhost"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    mock_subprocess_run.assert_any_call(
+        ["arp", "-n", "localhost"], capture_output=True, text=True
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
+import utils
 import subprocess
-from wolnut import utils
 
 def test_validate_mac_format():
   valid_mac_address = "de:ad:be:ef:be:ad"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ def test_validate_mac_format():
   assert not utils.validate_mac_format(invalid_mac_address)
 
 def test_resolve_mac_from_host(mocker):
-  # [ TODO ] - Write tests that assert the appropriate exceptions were raised
+  # [ TODO - Issue #24 ] - Write tests that assert the appropriate exceptions were raised
   class MockSubprocessResultOkay(object):
     stdout = "de:ad:be:ef:be:ad"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import subprocess
+from wolnut import utils
+
+def test_validate_mac_format():
+  valid_mac_address = "de:ad:be:ef:be:ad"
+  invalid_mac_address = "ea:ts:be:ef:be:ad"  # Mmm. Delicious beef bead.
+
+  # `validate_mac_format()` returns a bool, so no need to compare with `==`
+  assert utils.validate_mac_format(valid_mac_address)
+  assert not utils.validate_mac_format(invalid_mac_address)
+
+def test_resolve_mac_from_host(mocker):
+  # [ TODO ] - Write tests that assert the appropriate exceptions were raised
+  class MockSubprocessResultOkay(object):
+    stdout = "de:ad:be:ef:be:ad"
+
+  mock_subprocess_run = mocker.patch("utils.subprocess.run")
+  mock_subprocess_run.return_value = MockSubprocessResultOkay()
+  result = utils.resolve_mac_from_host('localhost')
+  assert result == MockSubprocessResultOkay.stdout
+  mock_subprocess_run.assert_any_call(["ping", "-c", "1", 'localhost'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+  mock_subprocess_run.assert_any_call(["arp", "-n", 'localhost'], capture_output=True, text=True)

--- a/tests/test_wol.py
+++ b/tests/test_wol.py
@@ -1,11 +1,11 @@
 def test_send_wol_packet(mocker):
-  # [ TODO - Issue #24 ] - Write tests that assert the appropriate exceptions were raised
+    # [ TODO - Issue #24 ] - Write tests that assert the appropriate exceptions were raised
 
-  # Normally, you'd patch an object. The funky order here is so that
-  # we can successfully patch a function. There's probably a better way to do this.
-  mock_send_magic_packet = mocker.patch("wakeonlan.send_magic_packet")
-  import wol
+    # Normally, you'd patch an object. The funky order here is so that
+    # we can successfully patch a function. There's probably a better way to do this.
+    mock_send_magic_packet = mocker.patch("wakeonlan.send_magic_packet")
+    import wol
 
-  # Intentionally using invalid values so an exception will be raised if the mock is wrong.
-  wol.send_wol_packet('testing', broadcast_ip='555.555')
-  mock_send_magic_packet.assert_called_once_with('testing', ip_address='555.555')
+    # Intentionally using invalid values so an exception will be raised if the mock is wrong.
+    wol.send_wol_packet("testing", broadcast_ip="555.555")
+    mock_send_magic_packet.assert_called_once_with("testing", ip_address="555.555")

--- a/tests/test_wol.py
+++ b/tests/test_wol.py
@@ -1,0 +1,9 @@
+def test_send_wol_packet(mocker):
+  # [ TODO ] - Write tests that assert the appropriate exceptions were raised
+  # Normally, you'd patch an object. The funky order here is so that
+  # we can successfully patch a function.
+  mock_send_magic_packet = mocker.patch("wakeonlan.send_magic_packet")
+  from wolnut import wol
+
+  wol.send_wol_packet('testing', broadcast_ip='555.555')
+  mock_send_magic_packet.assert_called_once_with('testing', ip_address='555.555')

--- a/tests/test_wol.py
+++ b/tests/test_wol.py
@@ -1,5 +1,5 @@
 def test_send_wol_packet(mocker):
-  # [ TODO ] - Write tests that assert the appropriate exceptions were raised
+  # [ TODO - Issue #24 ] - Write tests that assert the appropriate exceptions were raised
 
   # Normally, you'd patch an object. The funky order here is so that
   # we can successfully patch a function. There's probably a better way to do this.

--- a/tests/test_wol.py
+++ b/tests/test_wol.py
@@ -1,9 +1,11 @@
 def test_send_wol_packet(mocker):
   # [ TODO ] - Write tests that assert the appropriate exceptions were raised
-  # Normally, you'd patch an object. The funky order here is so that
-  # we can successfully patch a function.
-  mock_send_magic_packet = mocker.patch("wakeonlan.send_magic_packet")
-  from wolnut import wol
 
+  # Normally, you'd patch an object. The funky order here is so that
+  # we can successfully patch a function. There's probably a better way to do this.
+  mock_send_magic_packet = mocker.patch("wakeonlan.send_magic_packet")
+  import wol
+
+  # Intentionally using invalid values so an exception will be raised if the mock is wrong.
   wol.send_wol_packet('testing', broadcast_ip='555.555')
   mock_send_magic_packet.assert_called_once_with('testing', ip_address='555.555')

--- a/wolnut/main.py
+++ b/wolnut/main.py
@@ -7,6 +7,8 @@ from wolnut.wol import send_wol_packet
 
 logger = logging.getLogger("wolnut")
 
+# [ TODO - Issue #24 ] - As much as possible, break up `main()` into a collection of
+#                        smaller methods so that unit tests can be written
 
 def main():
     """MAIN LOOP"""
@@ -65,7 +67,7 @@ def main():
 
             if battery_percent < config.wake_on.min_battery_percent:
                 logger.info(
-                    """Power restored, but battery still below 
+                    """Power restored, but battery still below
                     minimum percentage (%s%%/%s%%). Waiting...""",
                     battery_percent,
                     config.wake_on.min_battery_percent)


### PR DESCRIPTION
Not quite where I planned to start with Issue #2, but this PR includes some (very) minimal unit tests, and a GitHub Actions Workflow to run them

Each time the job in this PR runs it will:
- Use `black --check` to point out files that could have improved formatting (running `black *.py` will fix these issues). This check is non-blocking.
- Run unit tests on the following python versions on both Ubuntu 22.02, and Ubuntu latest
  - `3.10`
  - `3.11`
  - `3.12`
  - `3.13`

This job only triggers on PRs. My thinking is that when a user opens a PR, they feel it is ready for review and as a result, their changes should be tested.

Here's an example of what a successful workflow run looks like:
https://github.com/dev-dull/wolnut/actions/runs/15936233833