### PR TITLE
fix: Making state file path configurable.  Updating to use click library for command line options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 .venv/
 *.log
 state.json
-config.yaml
+*config.yaml
 .vscode/
 .vscode/launch.json
 wolnut_state.json

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,7 @@ nut:
   password: "password"
 
 poll_interval: 15             # Poll interval in seconds — should be shorter than the NUT shutdown delay on any client
+status_file: "/app/wolnut_state.json"  # Path to status file, recommended you change this to be outside container if using Docker
 
 wake_on:
   restore_delay_sec: 30       # Delay (in seconds) after power is restored before sending WOL

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,84 @@
+# Configuration Guide
+
+The `wolnut` service is configured using a single YAML file, typically named `config.yaml`. This guide details all the available configuration options.
+
+## Top-Level Options
+
+These options are at the root of the configuration file.
+
+### `log_level`
+
+Sets the verbosity of the application's logs.
+
+-   **Type**: `string`
+-   **Default**: `"INFO"`
+-   **Options**: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
+
+### `poll_interval`
+
+The interval in seconds at which `wolnut` checks the status of the UPS and clients during normal operation (when not on battery power). This should generally be shorter than the shutdown delay configured on your NUT clients.
+
+-   **Type**: `integer`
+-   **Default**: `15`
+
+### `status_file`
+
+The file path where `wolnut` will store its state. This allows the service to resume its logic after a restart. It's highly recommended to map this file to a persistent volume when using Docker.
+
+-   **Type**: `string`
+-   **Default**: `"/app/wolnut_state.json"`
+
+---
+
+## `nut`
+
+Configuration for connecting to your NUT (Network UPS Tools) server.
+
+-   `ups`: **(Required)** The name and address of the UPS to monitor.
+    -   **Format**: `<ups-name>@<hostname-or-ip>`
+-   `hostname`: The hostname of the NUT server. Defaults to `localhost`.
+-   `port`: The port of the NUT server. Defaults to `3493`.
+-   `username`: The username for authenticating with the NUT server (optional).
+-   `password`: The password for authenticating with the NUT server (optional).
+
+---
+
+## `wake_on`
+
+Parameters that control the Wake-on-LAN behavior after power is restored.
+
+-   `restore_delay_sec`: The number of seconds to wait after AC power is restored before attempting to wake clients. This prevents sending WOL packets during brief power flickers.
+    -   **Default**: `30`
+-   `min_battery_percent`: `wolnut` will wait for the UPS battery to reach this percentage before sending WOL packets.
+    -   **Default**: `25`
+-   `client_timeout_sec`: The total time in seconds to wait for a client to come back online after a WOL packet has been sent. If the client doesn't appear online within this period, a warning is logged.
+    -   **Default**: `600`
+-   `reattempt_delay`: The minimum time in seconds between sending WOL packets to the same client if it doesn't come online.
+    -   **Default**: `30`
+
+---
+
+## `clients`
+
+A list of client machines to monitor and wake.
+
+Each item in the list is an object with the following properties:
+
+-   `name`: **(Required)** A human-readable name for the client. Used for logging.
+-   `host`: **(Required)** The IP address or hostname of the client. This is used to check if the client is online via ping.
+-   `mac`: **(Required)** The MAC address of the client's network interface.
+    -   **Value**: Can be a standard MAC address string (e.g., `"DE:AD:BE:EF:00:01"`) or `"auto"`.
+    -   If set to `"auto"`, `wolnut` will attempt to resolve the MAC address at startup using an ARP lookup based on the `host`.
+
+### Example `clients` block:
+
+```yaml
+clients:
+  - name: "desktop-pc"
+    host: "192.168.1.100"
+    mac: "38:f7:cd:c5:87:6b"
+
+  - name: "media-server"
+    host: "mediaserver.local"
+    mac: "auto" # wolnut will find the MAC address for you
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart Guide
+
+This guide will help you get `wolnut` running in a few simple steps using Docker.
+
+## Prerequisites
+
+- Docker installed and running.
+- A NUT (Network UPS Tools) server monitoring your UPS. See [Techno Tim's](https://technotim.live/posts/NUT-server-guide/) guide
+- The IP address or hostname of your NUT server, probably localhost.
+- The name of the UPS as configured in NUT (e.g., `ups`).
+
+## Step 1: Create Configuration Directory and File
+
+`wolnut` needs a configuration file to run. It's best to store this outside the container.
+
+1.  Create a directory to hold your configuration:
+    ```bash
+    mkdir ~/wolnut
+    ```
+
+2.  Create an empty configuration file inside that directory:
+    ```bash
+    touch ~/wolnut/config.yaml
+    ```
+
+## Step 2: Configure `config.yaml`
+
+Open `~/wolnut/config.yaml` in your favorite text editor and add the following minimal configuration. Be sure to replace the placeholder values with your actual details.
+
+```yaml
+# ~/wolnut/config.yaml
+
+nut:
+  # The name of your UPS as defined in your NUT server configuration.
+  # Format: <ups-name>@<nut-server-hostname-or-ip>
+  ups: "ups@localhost"
+
+status_file: "/config/wolnut_state.json" 
+
+clients:
+  - name: "my-pc"
+    host: "192.168.1.100" # IP address or hostname of the client machine
+    mac: "DE:AD:BE:EF:00:01" # MAC address of the client machine
+```
+
+For more advanced options, see the [Configuration](configuration.md) Guide.
+
+## Step 3: Run the Docker Container
+
+Run the following command to start the `wolnut` container. The `--network host` flag is required for Wake-on-LAN and for `wolnut` to communicate with your NUT server on the local network.
+
+```bash
+docker run -d \
+  --name wolnut \
+  --restart unless-stopped \
+  --network host \
+  -v ~/wolnut:/config \
+  hardwarehaven/wolnut:latest
+```
+
+## Step 4: Check the Logs
+
+You can check the logs to ensure `wolnut` started correctly and is monitoring your UPS.
+
+```bash
+docker logs wolnut
+```
+
+You should see output indicating that `wolnut` has started and successfully connected to your NUT server.
+
+That's it! `wolnut` is now running and will automatically wake your configured clients after a power outage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,11 @@ readme = "README.md"
 authors = [{ name = "hardwarehaven", email = "hardwarehaven.media@gmail.com" }]
 license = "MIT"
 requires-python = ">=3.11"
-dependencies = ["pyyaml>=6.0.2", "wakeonlan>=3.1.0",]
+dependencies = [
+    "click>=8.2.1",
+    "pyyaml>=6.0.2",
+    "wakeonlan>=3.1.0",
+]
 dynamic = ["version"]
 
 [tool.hatch.version]
@@ -15,7 +19,7 @@ path = "wolnut/__init__.py"
 default-groups = []
 
 [project.scripts]
-wolnut = "wolnut.cli:entrypoint"
+wolnut = "wolnut.cli:wolnut"
 
 [build-system]
 requires = ["hatchling"]

--- a/script/setup_env.sh
+++ b/script/setup_env.sh
@@ -32,7 +32,8 @@ else
     # Activate the virtual environment.
     source "${VIRTUAL_ENV}/bin/activate"
 
-    echo "🐍 Syncing uv..."
+    echo "🐍 Installing dependencies with uv..."
     uv sync --dev
+    uv pip install -e .
 
 fi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,9 +39,7 @@ def test_wolnut_cli_with_config_file_arg(runner, mocker):
 def test_wolnut_cli_with_env_var(runner, mocker):
     """Tests passing a config file via environment variable."""
     mock_main = mocker.patch("wolnut.cli.main")
-    mocker.patch(
-        "wolnut.cli.os.path.exists", return_value=False
-    )  # Ensure default paths aren't found
+    mocker.patch("wolnut.cli.os.path.exists", return_value=False)
 
     result = runner.invoke(
         wolnut,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,102 @@
+import pytest
+from click.testing import CliRunner
+
+from wolnut.cli import wolnut, get_battery_percent
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_get_battery_percent():
+    """Tests the battery percentage parsing function."""
+    assert get_battery_percent({"battery.charge": "95.5"}) == 96
+    assert get_battery_percent({"battery.charge": "20"}) == 20
+    assert get_battery_percent({}) == 100
+    assert get_battery_percent({"some_other_key": "value"}) == 100
+
+
+def test_wolnut_cli_no_config(runner, mocker):
+    """Tests the CLI response when no config file is found."""
+    mocker.patch("wolnut.cli.os.path.exists", return_value=False)
+    result = runner.invoke(wolnut)
+    assert "No config file found." in result.stdout
+    assert result.exit_code == 1
+
+
+def test_wolnut_cli_with_config_file_arg(runner, mocker):
+    """Tests passing a config file via command-line argument."""
+    mock_main = mocker.patch("wolnut.cli.main")
+    mocker.patch("wolnut.cli.os.path.exists", return_value=True)
+
+    result = runner.invoke(wolnut, ["--config-file", "/test/config.yaml"])
+
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with("/test/config.yaml", None, False)
+
+
+def test_wolnut_cli_with_env_var(runner, mocker):
+    """Tests passing a config file via environment variable."""
+    mock_main = mocker.patch("wolnut.cli.main")
+    mocker.patch(
+        "wolnut.cli.os.path.exists", return_value=False
+    )  # Ensure default paths aren't found
+
+    result = runner.invoke(
+        wolnut,
+        env={"WOLNUT_CONFIG_FILE": "/env/config.yaml"},
+    )
+
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with("/env/config.yaml", None, False)
+
+
+def test_wolnut_cli_finds_default_config(runner, mocker):
+    """Tests that the CLI finds a default config file path."""
+    mock_main = mocker.patch("wolnut.cli.main")
+    # Simulate the first default path not existing, but the second one does.
+    mocker.patch("wolnut.cli.os.path.exists", side_effect=[False, True])
+
+    result = runner.invoke(wolnut)
+
+    assert result.exit_code == 0
+    # Assumes the second default path is './config.yaml'
+    mock_main.assert_called_once_with("./config.yaml", None, False)
+
+
+def test_wolnut_cli_all_args(runner, mocker):
+    """Tests that all CLI arguments are passed to main correctly."""
+    mock_main = mocker.patch("wolnut.cli.main")
+    mocker.patch("wolnut.cli.os.path.exists", return_value=True)
+
+    result = runner.invoke(
+        wolnut,
+        ["--config-file", "a.yaml", "--status-file", "b.json", "--verbose"],
+    )
+
+    assert result.exit_code == 0
+    mock_main.assert_called_once_with("a.yaml", "b.json", True)
+
+
+def test_wolnut_cli_status_file_env_var(runner, mocker):
+    """Tests passing a status file via environment variable."""
+    mock_main = mocker.patch("wolnut.cli.main")
+    mocker.patch("wolnut.cli.os.path.exists", side_effect=[True])  # Find default config
+
+    result = runner.invoke(
+        wolnut,
+        env={"WOLNUT_STATUS_FILE": "/env/status.json"},
+    )
+
+    assert result.exit_code == 0
+    # The default config file path will be found and used
+    mock_main.assert_called_once_with("/config/config.yaml", "/env/status.json", False)
+
+
+def test_wolnut_cli_no_args_no_default_config(runner, mocker):
+    """Tests CLI when no arguments are given and no default config exists."""
+    mocker.patch("wolnut.cli.os.path.exists", return_value=False)
+    result = runner.invoke(wolnut)
+    assert "No config file found." in result.stdout
+    assert result.exit_code == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,9 +8,9 @@ from wolnut import config
 def minimal_config_dict():
     return {
         "nut": {"ups": "ups@localhost"},
-        "clients": [{
-            "name": "client-1", "host": "192.168.1.10", "mac": "DE:AD:BE:EF:00:01"
-        }],
+        "clients": [
+            {"name": "client-1", "host": "192.168.1.10", "mac": "DE:AD:BE:EF:00:01"}
+        ],
     }
 
 
@@ -57,7 +57,9 @@ def test_load_config_minimal(mocker, minimal_config_dict):
     assert cfg.poll_interval == 10  # Default
     assert cfg.wake_on.min_battery_percent == 20  # Default
     assert len(cfg.clients) == 1
-    assert cfg.clients[0].name == "client-1" # This was failing because host was missing
+    assert (
+        cfg.clients[0].name == "client-1"
+    )  # This was failing because host was missing
     assert cfg.log_level == "INFO"  # Default
 
 
@@ -125,7 +127,10 @@ def test_load_config_mac_resolution_fails(mocker, minimal_config_dict):
             "Client 'c1' is missing required field: 'host'",
         ),
         (
-            {"nut": {"ups": "ups"}, "clients": [{"name": "c1", "host": "h1"}]}, # This test is correct
+            {
+                "nut": {"ups": "ups"},
+                "clients": [{"name": "c1", "host": "h1"}],
+            },  # This test is correct
             "Client 'c1' is missing required field: 'mac'",
         ),
         (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,197 @@
+import pytest
+import yaml
+
+from wolnut import config
+
+
+@pytest.fixture
+def minimal_config_dict():
+    return {
+        "nut": {"ups": "ups@localhost"},
+        "clients": [{
+            "name": "client-1", "host": "192.168.1.10", "mac": "DE:AD:BE:EF:00:01"
+        }],
+    }
+
+
+@pytest.fixture
+def full_config_dict():
+    return {
+        "log_level": "DEBUG",
+        "poll_interval": 5,
+        "status_file": "/data/status.json",
+        "nut": {
+            "ups": "myups@nut-server",
+            "port": 1234,
+            "username": "monuser",
+            "password": "monpassword",
+        },
+        "wake_on": {
+            "restore_delay_sec": 60,
+            "min_battery_percent": 50,
+            "client_timeout_sec": 900,
+            "reattempt_delay": 45,
+        },
+        "clients": [
+            {
+                "name": "desktop",
+                "host": "desktop.local",
+                "mac": "DE:AD:BE:EF:00:01",
+            },
+            {"name": "server", "host": "server.local", "mac": "auto"},
+        ],
+    }
+
+
+def test_load_config_minimal(mocker, minimal_config_dict):
+    """Tests loading a minimal valid configuration."""
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data=yaml.dump(minimal_config_dict))
+    )
+    mocker.patch("wolnut.config.validate_config")
+    mocker.patch("wolnut.config.resolve_mac_from_host")  # Prevent actual resolution
+
+    cfg = config.load_config("dummy_path.yaml", None, False)
+
+    assert cfg.nut.ups == "ups@localhost"
+    assert cfg.poll_interval == 10  # Default
+    assert cfg.wake_on.min_battery_percent == 20  # Default
+    assert len(cfg.clients) == 1
+    assert cfg.clients[0].name == "client-1" # This was failing because host was missing
+    assert cfg.log_level == "INFO"  # Default
+
+
+def test_load_config_full(mocker, full_config_dict):
+    """Tests loading a full configuration with all options set."""
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data=yaml.dump(full_config_dict))
+    )
+    mocker.patch("wolnut.config.validate_config")
+    mock_resolve_mac = mocker.patch(
+        "wolnut.config.resolve_mac_from_host", return_value="11:22:33:44:55:66"
+    )
+
+    cfg = config.load_config("dummy_path.yaml", None, False)
+
+    assert cfg.log_level == "DEBUG"
+    assert cfg.poll_interval == 5
+    assert cfg.status_file == "/data/status.json"
+    assert cfg.nut.ups == "myups@nut-server"
+    assert cfg.nut.username == "monuser"
+    assert cfg.wake_on.restore_delay_sec == 60
+    assert cfg.wake_on.min_battery_percent == 50
+    assert len(cfg.clients) == 2
+    assert cfg.clients[0].mac == "DE:AD:BE:EF:00:01"
+    assert cfg.clients[1].mac == "11:22:33:44:55:66"  # Resolved MAC
+    mock_resolve_mac.assert_called_once_with("server.local")
+
+
+def test_load_config_file_not_found(mocker):
+    """Tests that None is returned when the config file is not found."""
+    mocker.patch("builtins.open", side_effect=FileNotFoundError)
+
+    result = config.load_config("nonexistent.yaml", None, False)
+
+    assert result is None
+
+
+def test_load_config_mac_resolution_fails(mocker, minimal_config_dict):
+    """Tests that a client is skipped if MAC address resolution fails."""
+    minimal_config_dict["clients"][0]["mac"] = "auto"
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data=yaml.dump(minimal_config_dict))
+    )
+    mocker.patch("wolnut.config.validate_config")
+    mocker.patch("wolnut.config.resolve_mac_from_host", return_value=None)
+
+    cfg = config.load_config("dummy.yaml", None, False)
+
+    # The client that failed resolution should not be in the final list
+    assert len(cfg.clients) == 0
+
+
+@pytest.mark.parametrize(
+    "invalid_config, error_msg",
+    [
+        ({"nut": {"ups": "ups"}}, "Missing or invalid 'clients' list"),
+        ({"clients": []}, "Missing required field: 'nut.ups'"),
+        ({"nut": {}, "clients": []}, "Missing required field: 'nut.ups'"),
+        (
+            {"nut": {"ups": "ups"}, "clients": [{}]},
+            "Client #0 is missing required field: 'name'",
+        ),
+        (
+            {"nut": {"ups": "ups"}, "clients": [{"name": "c1"}]},
+            "Client 'c1' is missing required field: 'host'",
+        ),
+        (
+            {"nut": {"ups": "ups"}, "clients": [{"name": "c1", "host": "h1"}]}, # This test is correct
+            "Client 'c1' is missing required field: 'mac'",
+        ),
+        (
+            {
+                "nut": {"ups": "ups"},
+                "clients": [{"name": "c1", "host": "h1", "mac": 12345}],
+            },
+            "has invalid mac format",
+        ),
+        (
+            {
+                "nut": {"ups": "ups"},
+                "clients": [{"name": "c1", "host": "h1", "mac": "invalid-mac"}],
+            },
+            "has invalid MAC address format",
+        ),
+    ],
+)
+def test_validate_config_failures(invalid_config, error_msg):
+    """Tests various invalid configuration scenarios for validate_config."""
+    with pytest.raises(ValueError, match=error_msg):
+        config.validate_config(invalid_config)
+
+
+def test_validate_config_success(minimal_config_dict):
+    """Tests that a valid config passes validation without error."""
+    try:
+        config.validate_config(minimal_config_dict)
+    except ValueError:
+        pytest.fail("validate_config raised ValueError unexpectedly")
+
+
+def test_load_config_status_path_override(mocker, minimal_config_dict):
+    """Tests that the status_path argument overrides the config file value."""
+    minimal_config_dict["status_file"] = "/config/status.json"
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data=yaml.dump(minimal_config_dict))
+    )
+    mocker.patch("wolnut.config.validate_config")
+    mocker.patch("wolnut.config.resolve_mac_from_host")
+
+    cfg = config.load_config("dummy.yaml", "/override/status.json", False)
+
+    assert cfg.status_file == "/override/status.json"
+
+
+def test_load_config_yaml_error(mocker):
+    """Tests that None is returned on a YAML parsing error."""
+    mocker.patch("builtins.open", mocker.mock_open(read_data="not: valid: yaml"))
+
+    result = config.load_config("bad.yaml", None, False)
+
+    assert result is None
+
+
+def test_load_config_verbose_flag(mocker, minimal_config_dict):
+    """Tests that the verbose flag overrides the log level in the config."""
+    minimal_config_dict["log_level"] = "INFO"
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data=yaml.dump(minimal_config_dict))
+    )
+    mocker.patch("wolnut.config.validate_config")
+    mocker.patch("wolnut.config.resolve_mac_from_host")
+
+    # The verbose flag is not actually used in load_config, but this test confirms
+    # the log_level is read from the file correctly when verbose is False.
+    # A more advanced test would involve checking the logger's level.
+    cfg = config.load_config("dummy.yaml", None, False)
+    assert cfg.log_level == "INFO"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import runpy
+import pytest
+
+
+def test_main_dunder(mocker):
+    """
+    Tests that running the __main__.py script calls the wolnut() function from the cli module.
+    """
+    mock_wolnut = mocker.patch("wolnut.cli.wolnut", return_value=99)
+    # Configure the mock to also raise SystemExit, just like the real sys.exit()
+    mock_exit = mocker.patch("sys.exit", side_effect=SystemExit)
+
+    with pytest.raises(SystemExit):
+        runpy.run_module("wolnut.__main__", run_name="__main__")
+
+    mock_wolnut.assert_called_once()
+    mock_exit.assert_called_once_with(status=99)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,12 +6,10 @@ def test_main_dunder(mocker):
     """
     Tests that running the __main__.py script calls the wolnut() function from the cli module.
     """
-    mock_wolnut = mocker.patch("wolnut.cli.wolnut", return_value=99)
-    # Configure the mock to also raise SystemExit, just like the real sys.exit()
-    mock_exit = mocker.patch("sys.exit", side_effect=SystemExit)
+    mock_wolnut = mocker.patch("wolnut.cli.wolnut", side_effect=SystemExit)
 
+    # The click entry point will raise a SystemExit, which is expected.
     with pytest.raises(SystemExit):
         runpy.run_module("wolnut.__main__", run_name="__main__")
 
     mock_wolnut.assert_called_once()
-    mock_exit.assert_called_once_with(status=99)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,100 +1,160 @@
+import pytest
 from wolnut import state
 
-# [ TODO - Issue #24 ] - These tests aren't really checking much of anything, and should
-#                        just be thought of as a scaffold to write real tests.
+
+# A simple mock client class for testing, as ClientStateTracker expects objects
+# with a `.name` attribute.
+class MockClient:
+    def __init__(self, name):
+        self.name = name
 
 
-def test__load_state(mocker):
-    mock_path_exists = mocker.patch("wolnut.state.os.path.exists")
-    mock_path_exists.return_value = False
-
-    s = state.ClientStateTracker([])
-    mock_path_exists.assert_called_once()
+@pytest.fixture
+def clients():
+    """Provides a standard list of mock clients for tests."""
+    return [MockClient("client-1"), MockClient("client-2")]
 
 
-def test__save_state(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s._save_state()
-    mock_file.assert_called_once()
+@pytest.fixture
+def tracker(clients, tmp_path):
+    """Provides a ClientStateTracker instance using a temporary state file."""
+    state_file = tmp_path / "wolnut_state.json"  # tmp_path is a pytest fixture
+    return state.ClientStateTracker(clients, status_file=str(state_file))
 
 
-def test_update(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s.update("no such client", False)
-    mock_file.assert_called_once()
+def test_initial_state(tracker):
+    """Tests that a new tracker initializes with correct default values."""
+    assert not tracker.was_ups_on_battery()
+    assert not tracker.is_online("client-1")
+    assert not tracker.was_online_before_shutdown("client-1")
+    assert not tracker.has_been_wol_sent("client-1")
+    assert not tracker.should_skip("client-1")
+    assert tracker.should_attempt_wol("client-1", 30)
 
 
-def test_mark_wol_sent(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s.mark_wol_sent("no such client")
-    mock_file.assert_called_once()
+def test_save_and_load_state(clients, tmp_path):
+    """Tests that state can be saved to a file and loaded back correctly."""
+    state_file = tmp_path / "wolnut_state.json"
+
+    # 1. Create a tracker, modify its state, which triggers saves.
+    tracker1 = state.ClientStateTracker(clients, status_file=str(state_file))
+    tracker1.update("client-1", True)
+    tracker1.mark_all_online_clients()
+    tracker1.mark_wol_sent("client-2")
+    tracker1.set_ups_on_battery(True, 50)
+
+    # 2. Create a new tracker instance from the same file.
+    tracker2 = state.ClientStateTracker(clients, status_file=str(state_file))
+
+    # 3. Assert that the state was loaded correctly.
+    assert tracker2.was_ups_on_battery()
+    assert tracker2._meta_state["battery_percent_at_shutdown"] == 50
+    assert tracker2.is_online("client-1")  # is_online state is persisted
+    assert tracker2.was_online_before_shutdown("client-1")
+    assert not tracker2.was_online_before_shutdown("client-2")
+    assert tracker2.has_been_wol_sent("client-2")
 
 
-def test_mark_skip(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s.mark_skip("no such client")
-    mock_file.assert_called_once()
+def test_load_state_corrupted_file(clients, tmp_path, caplog):
+    """Tests that a warning is logged when the state file is corrupted."""
+    state_file = tmp_path / "corrupted_state.json"
+    state_file.write_text("this is not valid json")
+
+    tracker = state.ClientStateTracker(clients, status_file=str(state_file))
+
+    # Assert that the state remains default
+    assert not tracker.was_ups_on_battery()
+    # Assert that a warning was logged
+    assert "Failed to load state from file" in caplog.text
 
 
-def test_mark_all_online_clients(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s.mark_all_online_clients()
-    mock_file.assert_called_once()
+def test_load_state_file_not_found(clients, tmp_path, caplog):
+    """Tests that a warning is logged when the state file doesn't exist."""
+    # Note: We don't create the file, just use the path.
+    state_file = tmp_path / "nonexistent.json"
+    state.ClientStateTracker(clients, status_file=str(state_file))
+    assert "State file does not exist, starting without." in caplog.text
 
 
-def test_is_online():
-    s = state.ClientStateTracker([])
-    assert not s.is_online("no such client")
+def test_update_and_is_online(tracker):
+    """Tests the update and is_online methods."""
+    assert not tracker.is_online("client-1")
+    tracker.update("client-1", True)
+    assert tracker.is_online("client-1")
+    tracker.update("client-1", False)
+    assert not tracker.is_online("client-1")
+    # Test that an unknown client correctly returns False
+    assert not tracker.is_online("unknown-client")
 
 
-def test_was_online_before_shutdown():
-    s = state.ClientStateTracker([])
-    assert not s.was_online_before_shutdown("no such client")
+def test_mark_all_online_clients(tracker):
+    """Tests marking all currently online clients for future WOL."""
+    tracker.update("client-1", True)
+    tracker.update("client-2", False)
+
+    tracker.mark_all_online_clients()
+
+    assert tracker.was_online_before_shutdown("client-1")
+    assert not tracker.was_online_before_shutdown("client-2")
 
 
-def test_has_been_wol_sent():
-    s = state.ClientStateTracker([])
-    assert not s.has_been_wol_sent("no such client")
+def test_should_attempt_wol(tracker, mocker):
+    """Tests the logic for WOL re-attempt delays based on time."""
+    reattempt_delay = 30
+    # Initially, we should always be able to attempt.
+    assert tracker.should_attempt_wol("client-1", reattempt_delay)
+
+    # Mark WOL as sent.
+    mock_time = mocker.patch("wolnut.state.time.time")
+    mock_time.return_value = 1000.0
+    tracker.mark_wol_sent("client-1")
+
+    # Immediately after, we should not attempt.
+    assert not tracker.should_attempt_wol("client-1", reattempt_delay)
+
+    # After some time, but less than the delay, we should not attempt.
+    mock_time.return_value = 1000.0 + reattempt_delay - 5
+    assert not tracker.should_attempt_wol("client-1", reattempt_delay)
+
+    # After the delay has passed, we should attempt.
+    mock_time.return_value = 1000.0 + reattempt_delay
+    assert tracker.should_attempt_wol("client-1", reattempt_delay)
 
 
-def test_should_attempt_wol():
-    s = state.ClientStateTracker([])
-    assert s.should_attempt_wol("no such client", 0)
-    assert s.should_attempt_wol("no such client", 100000)
-    assert s.should_attempt_wol("no such client", -5)
+def test_reset(tracker):
+    """Tests that the reset method clears the correct state fields."""
+    # Set some state to non-default values
+    tracker.update("client-1", True)
+    tracker.mark_wol_sent("client-1")
+    tracker.mark_skip("client-2")
+
+    # Sanity check
+    assert tracker.has_been_wol_sent("client-1")
+    assert tracker.should_skip("client-2")
+
+    tracker.reset()
+
+    # Assert that resettable fields are cleared
+    assert not tracker.has_been_wol_sent("client-1")
+    assert not tracker.should_skip("client-2")
+    # is_online is not part of the reset logic, it reflects current state.
+    assert tracker.is_online("client-1")
 
 
-def test_should_skip():
-    s = state.ClientStateTracker([])
-    assert not s.should_skip("no such client")
+def test_mark_and_should_skip(tracker):
+    """Tests the mark_skip and should_skip methods."""
+    assert not tracker.should_skip("client-1")
+    tracker.mark_skip("client-1")
+    assert tracker.should_skip("client-1")
 
 
-def test_set_ups_on_battery(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s.set_ups_on_battery(True, 9001)
-    assert s._meta_state["ups_on_battery"]
-    assert (
-        s._meta_state["battery_percent_at_shutdown"] > 9000
-    )  # this should _really_ test for equality (`==`) but, its_over_9000.jpeg
-    mock_file.assert_called_once()
+def test_set_and_was_ups_on_battery(tracker):
+    """Tests the set_ups_on_battery and was_ups_on_battery methods."""
+    assert not tracker.was_ups_on_battery()
+    tracker.set_ups_on_battery(True, 75)
+    assert tracker.was_ups_on_battery()
+    assert tracker._meta_state["battery_percent_at_shutdown"] == 75
 
-
-def test_was_ups_on_battery():
-    s = state.ClientStateTracker([])
-    assert not s._meta_state["ups_on_battery"]
-
-
-def test_reset(mocker):
-    mock_file = mocker.patch("builtins.open")
-    s = state.ClientStateTracker([])
-    s.reset()
-    for client_state in s._client_states.values():
-        for key in ["was_online_before_battery", "wol_sent", "skip"]:
-            assert not client_state[key]
-    mock_file.assert_called_once()
+    tracker.set_ups_on_battery(False, 100)
+    assert not tracker.was_ups_on_battery()
+    assert tracker._meta_state["battery_percent_at_shutdown"] == 100

--- a/uv.lock
+++ b/uv.lock
@@ -323,6 +323,7 @@ wheels = [
 name = "wolnut"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "pyyaml" },
     { name = "wakeonlan" },
 ]
@@ -349,6 +350,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.2.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "wakeonlan", specifier = ">=3.1.0" },
 ]

--- a/wolnut/__main__.py
+++ b/wolnut/__main__.py
@@ -1,4 +1,6 @@
-from wolnut.cli import entrypoint
+import sys
+
+from wolnut.cli import wolnut
 
 if __name__ == "__main__":
-    entrypoint()
+    sys.exit(status=wolnut())

--- a/wolnut/__main__.py
+++ b/wolnut/__main__.py
@@ -3,4 +3,4 @@ import sys
 from wolnut.cli import wolnut
 
 if __name__ == "__main__":
-    sys.exit(status=wolnut())
+    wolnut()

--- a/wolnut/cli.py
+++ b/wolnut/cli.py
@@ -1,6 +1,9 @@
-import time
+import click
 import logging
-from wolnut.config import load_config
+import os
+import time
+
+from wolnut.config import load_config, DEFAULT_CONFIG_FILEPATHS
 from wolnut.state import ClientStateTracker
 from wolnut.monitor import get_ups_status, is_client_online
 from wolnut.wol import send_wol_packet
@@ -12,9 +15,11 @@ def get_battery_percent(ups_status):
     return round(float(ups_status.get("battery.charge", 100)))
 
 
-def main():
+def main(config_file: str, status_file: str, verbose: bool = False) -> int:
     """MAIN LOOP"""
-    config = load_config()
+    config = load_config(config_file, status_file=status_file, verbose=verbose)
+    if not config:
+        return 1
 
     logger.setLevel(config.log_level)
     logger.info("WOLNUT started. Monitoring UPS: %s", config.nut.ups)
@@ -27,7 +32,7 @@ def main():
     restoration_event_start = None
     wol_being_sent = False
 
-    state_tracker = ClientStateTracker(config.clients)
+    state_tracker = ClientStateTracker(config.clients, status_file=config.status_file)
     if state_tracker.was_ups_on_battery():
         logger.info("WOLNUT is resuming from a UPS battery event")
         restoration_event = True
@@ -169,10 +174,31 @@ def main():
             time.sleep(2)
 
 
-def entrypoint():
+@click.command()
+@click.option("--config-file", default=None, help="The configuration filepath to load")
+@click.option("--status-file", default=None, help="The status filepath to load")
+@click.option("--verbose", is_flag=True, help="Enable verbose logging")
+def wolnut(config_file=None, status_file=None, verbose=False) -> int:
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
 
-    return main()
+    if config_file is None:
+        if os.environ.get("WOLNUT_CONFIG_FILE") is not None:
+            config_file = os.environ.get("WOLNUT_CONFIG_FILE")
+        else:
+            for path in DEFAULT_CONFIG_FILEPATHS:
+                if os.path.exists(path):
+                    config_file = path
+                    break
+            if config_file is None:
+                click.echo("No config file found. Checked paths:")
+                for path in DEFAULT_CONFIG_FILEPATHS:
+                    click.echo(f" - {path}")
+                raise click.Abort()
+
+    if status_file is None:
+        status_file = os.environ.get("WOLNUT_STATUS_FILE")
+
+    return main(config_file, status_file, verbose)

--- a/wolnut/cli.py
+++ b/wolnut/cli.py
@@ -193,10 +193,6 @@ def wolnut(config_file: str | None, status_file: str | None, verbose: bool) -> i
     )
 
     if config_file is None:
-        if os.environ.get("WOLNUT_CONFIG_FILE") is not None:
-            config_file = os.environ["WOLNUT_CONFIG_FILE"]
-
-    if config_file is None:
         for path in DEFAULT_CONFIG_FILEPATHS:
             if os.path.exists(path):
                 config_file = path

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -1,18 +1,22 @@
-from dataclasses import dataclass, field
-import yaml
 import logging
 import os
 import sys
+import yaml
 
+from dataclasses import dataclass, field
+from typing import Optional
+
+from wolnut.state import DEFAULT_STATE_FILEPATH
 from wolnut.utils import validate_mac_format, resolve_mac_from_host
 
 logger = logging.getLogger("wolnut")
+
+DEFAULT_CONFIG_FILEPATHS = ["/config/config.yaml", "./config.yaml"]
 
 
 @dataclass
 class NutConfig:
     ups: str
-    hostname: str = "localhost"
     port: int = 3493
     timeout: int = 5
     username: str | None = None
@@ -37,32 +41,25 @@ class ClientConfig:
 @dataclass
 class WolnutConfig:
     nut: NutConfig
+    status_file: str
     poll_interval: int = 10
     wake_on: WakeOnConfig = field(default_factory=WakeOnConfig)
     clients: list[ClientConfig] = field(default_factory=list)
     log_level: str = "INFO"
 
-
-def load_config(path: str = None) -> WolnutConfig:
-
-    if path is None:
-        # Prefer /config/config.yaml if it exists
-        default_path = "/config/config.yaml"
-        if os.path.exists(default_path):
-            path = default_path
-        else:
-            path = "config.yaml"
-
+def load_config(
+    config_path: str, status_path: str = None, verbose: bool = False
+) -> Optional[WolnutConfig]:
     try:
-        with open(path, "r") as f:
+        with open(config_path, "r") as f:
             raw = yaml.safe_load(f)
         validate_config(raw)
     except FileNotFoundError:
-        logger.error("Config file not found at '%s'.", path)
-        sys.exit(1)
-    except Exception as e:
-        logger.error("Failed to load or parse config file: %s", e)
-        sys.exit(1)
+        logger.error("Config file not found at '%s'.", config_path)
+        return None
+    except Exception:
+        logger.exception("Failed to load or parse config file: '%s'.\n", config_path)
+        return None
 
     # LOGGING...
     nut = NutConfig(**raw["nut"])
@@ -70,7 +67,8 @@ def load_config(path: str = None) -> WolnutConfig:
     # get wake_on or use defaults
     wake_on = WakeOnConfig(**raw.get("wake_on", {}))
 
-    # LOGGING...
+    if status_path is None:
+        status_path = raw.get("status_file", DEFAULT_STATE_FILEPATH)
 
     clients = []
     for raw_client in raw["clients"]:
@@ -100,6 +98,7 @@ def load_config(path: str = None) -> WolnutConfig:
         wake_on=wake_on,
         clients=clients,
         log_level=raw.get("log_level", "INFO").upper(),
+        status_file=status_path,
     )
     logger.info("Config Imported Successfully")
     for client in wolnut_config.clients:
@@ -114,6 +113,9 @@ def validate_config(raw: dict):
 
     if "nut" not in raw or "ups" not in raw["nut"]:
         raise ValueError("Missing required field: 'nut.ups'")
+
+    if "status_file" not in raw:
+        logger.warning("No 'status_file' specified in config, using default.")
 
     for i, client in enumerate(raw["clients"]):
         if "name" not in client:

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -47,6 +47,7 @@ class WolnutConfig:
     clients: list[ClientConfig] = field(default_factory=list)
     log_level: str = "INFO"
 
+
 def load_config(
     config_path: str, status_path: str = None, verbose: bool = False
 ) -> Optional[WolnutConfig]:


### PR DESCRIPTION
Making config and persistent state files configurable on the command line, or via environment variable #17 .  Updating main to use the click library for command line options #16 .  Adding unit tests, quickstart guide and configuration file reference.