### PR TITLE
fix: Make wolnut much more careful about writing to the state file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,11 @@ This helps reboot systems automatically after a controlled shutdown caused by a 
 
 ---
 
-## Docker
+## Quickstart
 
-WOLNUT looks for /config/config.yaml on startup. 
-
-```bash
-mkdir ~/wolnut
-touch config.yaml
-```
-Then copy the config.example.yaml as a starting point. 
-### Docker Run
-```bash
-docker run -d \
-  --name wolnut \
-  --restart unless-stopped \
-  -v ~/wolnut:/config \
-  --network host \
-  hardwarehaven/wolnut:latest
-```
+See the [Quickstart](docs/quickstart.md) guide.
 
 ### Docker Compose
+
 See [docker-compose.yml](docker-compose.yml) for an example docker compose file
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,7 @@ nut:
   password: "password"
 
 poll_interval: 15             # Poll interval in seconds — should be shorter than the NUT shutdown delay on any client
-status_file: "/app/wolnut_state.json"  # Path to status file, recommended you change this to be outside container if using Docker
+status_file: "/config/wolnut_state.json"  # Path to status file, recommended you change this to be outside container if using Docker
 
 wake_on:
   restore_delay_sec: 30       # Delay (in seconds) after power is restored before sending WOL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
         network_mode: host
         restart: unless-stopped
         volumes:
-            - ./config.yaml:/config/config.yaml
+            - ~/wolnut:/config
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,10 +23,10 @@ The interval in seconds at which `wolnut` checks the status of the UPS and clien
 
 ### `status_file`
 
-The file path where `wolnut` will store its state. This allows the service to resume its logic after a restart. It's highly recommended to map this file to a persistent volume when using Docker.
+The file path where `wolnut` will store its state. This allows the service to resume its logic after a restart. It's highly recommended to map this file to a persistent writeable volume when using Docker.
 
 -   **Type**: `string`
--   **Default**: `"/app/wolnut_state.json"`
+-   **Default**: `"/config/wolnut_state.json"`
 
 ---
 
@@ -35,7 +35,7 @@ The file path where `wolnut` will store its state. This allows the service to re
 Configuration for connecting to your NUT (Network UPS Tools) server.
 
 -   `ups`: **(Required)** The name and address of the UPS to monitor.
-    -   **Format**: `<ups-name>@<hostname-or-ip>`
+    -   **Format**: `<ups-name>`, supports deprecated `<ups-name>@<hostname>` for backward compatibilty.
 -   `hostname`: The hostname of the NUT server. Defaults to `localhost`.
 -   `port`: The port of the NUT server. Defaults to `3493`.
 -   `username`: The username for authenticating with the NUT server (optional).
@@ -69,6 +69,7 @@ Each item in the list is an object with the following properties:
 -   `mac`: **(Required)** The MAC address of the client's network interface.
     -   **Value**: Can be a standard MAC address string (e.g., `"DE:AD:BE:EF:00:01"`) or `"auto"`.
     -   If set to `"auto"`, `wolnut` will attempt to resolve the MAC address at startup using an ARP lookup based on the `host`.
+
 
 ### Example `clients` block:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,9 +32,11 @@ Open `~/wolnut/config.yaml` in your favorite text editor and add the following m
 
 nut:
   # The name of your UPS as defined in your NUT server configuration.
-  # Format: <ups-name>@<nut-server-hostname-or-ip>
-  ups: "ups@localhost"
+  # Format: <ups-name>
+  ups: "ups"
+  hostname: "127.0.0.1"  # not needed if running localhost/127.0.0.1
 
+# The directory for the status file should be writable. It will be created if it doesn't exist.
 status_file: "/config/wolnut_state.json" 
 
 clients:
@@ -57,6 +59,10 @@ docker run -d \
   -v ~/wolnut:/config \
   hardwarehaven/wolnut:latest
 ```
+
+### Docker Compose
+
+See [docker-compose.yml](docker-compose.yml) for an example docker compose file
 
 ## Step 4: Check the Logs
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
+from wolnut import main
 from wolnut.cli import wolnut, get_battery_percent
 
 
@@ -25,9 +26,29 @@ def test_wolnut_cli_no_config(runner, mocker):
     assert result.exit_code == 1
 
 
+def test_wolnut_cli_verbose_flag(runner, mocker):
+    """Tests that the --verbose flag sets the log level to DEBUG."""
+    mock_main = mocker.patch("wolnut.cli.main", return_value=0)
+    mocker.patch("wolnut.cli.os.path.exists", return_value=True)
+    mock_configure_logger = mocker.patch(
+        "wolnut.cli.configure_logger"
+    )  # This will now work
+
+    # The main function is mocked, so we don't need to mock load_config.
+    # The logger configuration happens in the `wolnut` CLI function itself.
+
+    result = runner.invoke(wolnut, ["--verbose"])
+
+    assert result.exit_code == 0
+    # The verbose flag should set the log level to DEBUG before main is called.
+    mock_configure_logger.assert_called_once_with("DEBUG")
+    # And main should be called with verbose=True
+    mock_main.assert_called_once_with("/config/config.yaml", None, True)
+
+
 def test_wolnut_cli_with_config_file_arg(runner, mocker):
     """Tests passing a config file via command-line argument."""
-    mock_main = mocker.patch("wolnut.cli.main")
+    mock_main = mocker.patch("wolnut.cli.main", return_value=0)
     mocker.patch("wolnut.cli.os.path.exists", return_value=True)
 
     result = runner.invoke(wolnut, ["--config-file", "/test/config.yaml"])
@@ -38,7 +59,7 @@ def test_wolnut_cli_with_config_file_arg(runner, mocker):
 
 def test_wolnut_cli_with_env_var(runner, mocker):
     """Tests passing a config file via environment variable."""
-    mock_main = mocker.patch("wolnut.cli.main")
+    mock_main = mocker.patch("wolnut.cli.main", return_value=0)
     mocker.patch("wolnut.cli.os.path.exists", return_value=False)
 
     result = runner.invoke(
@@ -52,7 +73,7 @@ def test_wolnut_cli_with_env_var(runner, mocker):
 
 def test_wolnut_cli_finds_default_config(runner, mocker):
     """Tests that the CLI finds a default config file path."""
-    mock_main = mocker.patch("wolnut.cli.main")
+    mock_main = mocker.patch("wolnut.cli.main", return_value=0)
     # Simulate the first default path not existing, but the second one does.
     mocker.patch("wolnut.cli.os.path.exists", side_effect=[False, True])
 
@@ -65,7 +86,7 @@ def test_wolnut_cli_finds_default_config(runner, mocker):
 
 def test_wolnut_cli_all_args(runner, mocker):
     """Tests that all CLI arguments are passed to main correctly."""
-    mock_main = mocker.patch("wolnut.cli.main")
+    mock_main = mocker.patch("wolnut.cli.main", return_value=0)
     mocker.patch("wolnut.cli.os.path.exists", return_value=True)
 
     result = runner.invoke(
@@ -79,7 +100,7 @@ def test_wolnut_cli_all_args(runner, mocker):
 
 def test_wolnut_cli_status_file_env_var(runner, mocker):
     """Tests passing a status file via environment variable."""
-    mock_main = mocker.patch("wolnut.cli.main")
+    mock_main = mocker.patch("wolnut.cli.main", return_value=0)
     mocker.patch("wolnut.cli.os.path.exists", side_effect=[True])  # Find default config
 
     result = runner.invoke(
@@ -90,11 +111,3 @@ def test_wolnut_cli_status_file_env_var(runner, mocker):
     assert result.exit_code == 0
     # The default config file path will be found and used
     mock_main.assert_called_once_with("/config/config.yaml", "/env/status.json", False)
-
-
-def test_wolnut_cli_no_args_no_default_config(runner, mocker):
-    """Tests CLI when no arguments are given and no default config exists."""
-    mocker.patch("wolnut.cli.os.path.exists", return_value=False)
-    result = runner.invoke(wolnut)
-    assert "No config file found." in result.stdout
-    assert result.exit_code == 1

--- a/wolnut/cli.py
+++ b/wolnut/cli.py
@@ -176,6 +176,8 @@ def main(config_file: str, status_file: str, verbose: bool = False) -> int:
             recorded_down_clients.clear()
             recorded_up_clients.clear()
 
+        state_tracker.save_state()
+
         if not on_battery:
             time.sleep(config.poll_interval)
         else:

--- a/wolnut/cli.py
+++ b/wolnut/cli.py
@@ -11,6 +11,14 @@ from wolnut.wol import send_wol_packet
 logger = logging.getLogger("wolnut")
 
 
+def configure_logger(level: str):
+    """
+    Configures the root logger's level.
+    Needed for unit testing since logging.basicConfig is a no-op if the root logger already has handlers.
+    """
+    logger.setLevel(level)
+
+
 def get_battery_percent(ups_status):
     return round(float(ups_status.get("battery.charge", 100)))
 
@@ -21,7 +29,7 @@ def main(config_file: str, status_file: str, verbose: bool = False) -> int:
     if not config:
         return 1
 
-    logger.setLevel(config.log_level)
+    configure_logger(config.log_level)
     logger.info("WOLNUT started. Monitoring UPS: %s", config.nut.ups)
 
     on_battery = False
@@ -187,10 +195,14 @@ def main(config_file: str, status_file: str, verbose: bool = False) -> int:
 )
 @click.option("--verbose", is_flag=True, help="Enable verbose logging")
 def wolnut(config_file: str | None, status_file: str | None, verbose: bool) -> int:
+    """A service to send Wake-on-LAN packets to clients after a power outage."""
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
+
+    if verbose:
+        configure_logger("DEBUG")
 
     if config_file is None:
         for path in DEFAULT_CONFIG_FILEPATHS:
@@ -203,6 +215,7 @@ def wolnut(config_file: str | None, status_file: str | None, verbose: bool) -> i
             )
             raise click.Abort()
 
-    if not main(config_file, status_file, verbose):
-        click.Abort()
-    return 0
+    exit_code = main(config_file, status_file, verbose)
+    if exit_code != 0:
+        # main() will log the specific error, so we just abort.
+        raise click.Abort()

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 import yaml
 
 from dataclasses import dataclass, field
@@ -12,6 +11,7 @@ from wolnut.utils import validate_mac_format, resolve_mac_from_host
 logger = logging.getLogger("wolnut")
 
 DEFAULT_CONFIG_FILEPATHS = ["/config/config.yaml", "./config.yaml"]
+DEFAULT_LOG_LEVEL = "INFO"
 
 
 @dataclass
@@ -98,7 +98,7 @@ def load_config(
         poll_interval=raw.get("poll_interval", 10),
         wake_on=wake_on,
         clients=clients,
-        log_level=raw.get("log_level", "INFO").upper(),
+        log_level=raw.get("log_level", DEFAULT_LOG_LEVEL).upper(),
         status_file=status_path,
     )
     logger.info("Config Imported Successfully")

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -1,8 +1,8 @@
 import logging
-import os
 import yaml
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 from wolnut.state import DEFAULT_STATE_FILEPATH
@@ -48,6 +48,22 @@ class WolnutConfig:
     log_level: str = "INFO"
 
 
+def find_state_file(state_file: Optional[str] = None) -> str:
+    """Find an existing state file or return a writable default path."""
+    path = Path(state_file or DEFAULT_STATE_FILEPATH)
+    if not state_file:
+        logger.warning("No state file specified, using default: %s", path)
+
+    # Ensure the parent directory exists
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.error("Could not create directory for state file '%s': %s", path, e)
+        # Depending on desired behavior, you might want to exit or raise here.
+
+    return str(path)
+
+
 def load_config(
     config_path: str, status_path: str = None, verbose: bool = False
 ) -> Optional[WolnutConfig]:
@@ -68,8 +84,10 @@ def load_config(
     # get wake_on or use defaults
     wake_on = WakeOnConfig(**raw.get("wake_on", {}))
 
-    if status_path is None:
-        status_path = raw.get("status_file", DEFAULT_STATE_FILEPATH)
+    # Determine status file path: CLI arg > config file > default
+    final_status_path = status_path or raw.get("status_file")
+    # find_state_file will handle None and also ensure the directory exists
+    final_status_path = find_state_file(final_status_path)
 
     clients = []
     for raw_client in raw["clients"]:
@@ -99,7 +117,7 @@ def load_config(
         wake_on=wake_on,
         clients=clients,
         log_level=raw.get("log_level", DEFAULT_LOG_LEVEL).upper(),
-        status_file=status_path,
+        status_file=final_status_path,
     )
     logger.info("Config Imported Successfully")
     for client in wolnut_config.clients:

--- a/wolnut/state.py
+++ b/wolnut/state.py
@@ -1,13 +1,15 @@
 import json
 import logging
-import os
 import time
 
-from typing import Dict, Any
+from hashlib import md5
+from pathlib import Path
+from typing import Dict, Any, Optional, List
 
 logger = logging.getLogger("wolnut")
 
-DEFAULT_STATE_FILEPATH = "/app/wolnut_state.json"
+DEFAULT_STATE_FILEPATH = "/config/wolnut_state.json"
+ASSUME_UNINITIALIZED_ONLINE = False  # Assume clients are online if no state file exists
 
 
 class ClientStateTracker:
@@ -28,71 +30,125 @@ class ClientStateTracker:
         ...
     """
 
-    def __init__(self, clients, status_file: str = DEFAULT_STATE_FILEPATH):
-        self._clients = clients
-        self._status_file = status_file
+    def __init__(self, clients: List[Any], status_file: str):
+        # Search default locations for existing state file
+        if not status_file:
+            raise ValueError("A status file must be specified.")
+
+        self._status_file = Path(status_file)  # Filename for storing state data
+        self._status_hash = None  # Hash of the current/previous status file contents
+        self._dirty = False  # Whether the state has changed since last save
         self._meta_state: Dict[str, Any] = {
             "ups_on_battery": False,
             "battery_percent_at_shutdown": 100,
         }
+        self._client_states: Dict[str, Dict[str, Any]] = {}
 
-        self._client_states: Dict[str, Dict[str, Any]] = {
-            client.name: {
-                "was_online_before_battery": False,
-                "is_online": False,
-                "wol_sent": False,
-                "wol_sent_at": 0,
-                "skip": False,
-            }
-            for client in clients
-        }
-        self._load_state()
+        # Load existing state from file first
+        if self._status_file.exists():
+            self._load_state()
+
+        # Initialize any clients not in the loaded state
+        for client in clients:
+            if client.name not in self._client_states:
+                self._client_states[client.name] = {
+                    "was_online_before_battery": ASSUME_UNINITIALIZED_ONLINE,
+                    "is_online": False,
+                    "wol_sent": False,
+                    "wol_sent_at": 0,
+                    "skip": False,
+                }
 
     def _load_state(self):
-        if not os.path.exists(self._status_file):
-            logger.warning("State file does not exist, starting without.")
-            return
+        """
+        Loads the state from the JSON file, if it exists.
+        """
         try:
             with open(self._status_file, "r") as f:
-                save_data = json.load(f)
+                raw_data = f.read()
 
+            # Remember the hash of the loaded data to avoid unnecessary writes later
+            # I'm aware that md5 is not cryptographically secure, but this is not a security use case.
+            status_hash = md5(raw_data.encode("utf-8")).hexdigest()
+            save_data = json.loads(raw_data)
             self._meta_state.update(save_data["meta"])
-
-            for name, state in save_data.get("clients", {}).items():
-                if name in self._client_states:
-                    self._client_states[name].update(state)
-
+            self._client_states = save_data.get("clients", {})
+            self._status_hash = status_hash
+            logger.info("State loaded from %s", self._status_file)
         except Exception as e:
             logger.warning("Failed to load state from file: %s", e)
 
-    def _save_state(self):
+    def save_state(self):
+        """
+        Saves the current state to the JSON file, if it has changed since the last save.
+        The number of try/except blocks is intentional to ensure that errors are well
+        documentented for debugging.
+        """
+        if not self._dirty:
+            return
+
         save_data = {"meta": self._meta_state, "clients": self._client_states}
         try:
-            with open(self._status_file, "w") as f:
-                json.dump(save_data, f)
-        except Exception as e:
-            logger.warning("Failed to save state to file: %s", e)
+            # Make it pretty for humans
+            raw_data = json.dumps(
+                save_data, indent=4, separators=(",", ": "), sort_keys=True
+            )
+            new_hash = md5(raw_data.encode("utf-8")).hexdigest()
+            if self._status_hash == new_hash:
+                logging.debug("State unchanged, skipping save.")
+                return
+        except Exception:
+            logger.exception("Failed to serialize state to JSON.")
+            return
+
+        temp_state_file = self._status_file.with_suffix(".json.tmp")
+        try:
+            with temp_state_file.open("w") as f:
+                f.write(raw_data)
+        except Exception:
+            logger.exception(
+                "Failed to write temporary state file: '%s'", temp_state_file
+            )
+            return
+
+        try:
+            temp_state_file.replace(self._status_file)
+        except Exception:
+            logger.exception(
+                "Failed to move temporary state to permanent: '%s' to '%s'",
+                temp_state_file,
+                self._status_file,
+            )
+
+        self._status_hash = new_hash
+        self._dirty = False
+        logger.debug("State saved to %s", self._status_file)
 
     def update(self, client_name: str, online: bool):
-        if client_name in self._client_states:
+        if (
+            client_name in self._client_states
+            and self._client_states[client_name]["is_online"] != online
+        ):
             self._client_states[client_name]["is_online"] = online
-        self._save_state()
+            self._dirty = True
 
     def mark_wol_sent(self, client_name: str):
         if client_name in self._client_states:
             self._client_states[client_name]["wol_sent"] = True
-            self._client_states[client_name]["wol_sent_at"] = time.time()
-        self._save_state()
+            self._client_states[client_name]["wol_sent_at"] = int(time.time())
+            self._dirty = True
 
     def mark_skip(self, client_name: str):
-        if client_name in self._client_states:
+        if client_name in self._client_states and not self._client_states[
+            client_name
+        ].get("skip", False):
             self._client_states[client_name]["skip"] = True
-        self._save_state()
+            self._dirty = True
 
     def mark_all_online_clients(self):
         for name, state in self._client_states.items():
             state["was_online_before_battery"] = state["is_online"]
-        self._save_state()
+            self._dirty = True
 
     def is_online(self, client_name: str) -> bool:
         return self._client_states.get(client_name, {}).get("is_online", False)
@@ -114,16 +170,27 @@ class ClientStateTracker:
         return self._client_states.get(client_name, {}).get("skip", False)
 
     def set_ups_on_battery(self, is_on_battery: bool, battery_percent: int = 100):
-        self._meta_state["ups_on_battery"] = is_on_battery
-        self._meta_state["battery_percent_at_shutdown"] = battery_percent
-        self._save_state()
+        if self._meta_state["ups_on_battery"] != is_on_battery:
+            self._meta_state["ups_on_battery"] = is_on_battery
+            self._dirty = True
+
+        if self._meta_state["battery_percent_at_shutdown"] != battery_percent:
+            self._meta_state["battery_percent_at_shutdown"] = battery_percent
+            self._dirty = True
 
     def was_ups_on_battery(self) -> bool:
         return self._meta_state["ups_on_battery"]
 
     def reset(self):
         for state in self._client_states.values():
-            state["was_online_before_battery"] = False
-            state["wol_sent"] = False
-            state["skip"] = False
-        self._save_state()
+            state.update(
+                {
+                    "was_online_before_battery": False,
+                    "wol_sent": False,
+                    "wol_sent_at": 0,
+                    "skip": False,
+                }
+            )
+        # Also reset the meta state for a complete reset
+        self.set_ups_on_battery(False)
+        self._dirty = True


### PR DESCRIPTION
Given that the state file is likely writing to an SD card, in a volatile environment where power could be lost without warning, it makes sense to write infrequently and atomically where possible.

Additionally, I'm modifying the default location for the state file to the /config directory in the expectation that this should be external to the docker image.  