### PR TITLE
docs: align NUT config docs with runtime behavior

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,8 +3,6 @@ log_level: INFO  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 nut:
   ups: "ups@localhost"        # Format: <ups-name>@<host>
-  username: "upsmon"          # Optional: omit if NUT server doesn't require auth
-  password: "password"
 
 poll_interval: 15             # Poll interval in seconds — should be shorter than the NUT shutdown delay on any client
 status_file: "/config/wolnut_state.json"  # Path to status file, recommended you change this to be outside container if using Docker

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,9 +36,6 @@ Configuration for connecting to your NUT (Network UPS Tools) server.
 
 -   `ups`: **(Required)** The name and address of the UPS to monitor.
     -   **Format**: `<ups-name>@<hostname>` (for example: `ups@localhost`).
--   `port`: The port of the NUT server. Defaults to `3493`.
--   `username`: The username for authenticating with the NUT server (optional).
--   `password`: The password for authenticating with the NUT server (optional).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,8 +35,7 @@ The file path where `wolnut` will store its state. This allows the service to re
 Configuration for connecting to your NUT (Network UPS Tools) server.
 
 -   `ups`: **(Required)** The name and address of the UPS to monitor.
-    -   **Format**: `<ups-name>`, supports deprecated `<ups-name>@<hostname>` for backward compatibilty.
--   `hostname`: The hostname of the NUT server. Defaults to `localhost`.
+    -   **Format**: `<ups-name>@<hostname>` (for example: `ups@localhost`).
 -   `port`: The port of the NUT server. Defaults to `3493`.
 -   `username`: The username for authenticating with the NUT server (optional).
 -   `password`: The password for authenticating with the NUT server (optional).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,9 +32,8 @@ Open `~/wolnut/config.yaml` in your favorite text editor and add the following m
 
 nut:
   # The name of your UPS as defined in your NUT server configuration.
-  # Format: <ups-name>
-  ups: "ups"
-  hostname: "127.0.0.1"  # not needed if running localhost/127.0.0.1
+  # Format: <ups-name>@<hostname>
+  ups: "ups@localhost"
 
 # The directory for the status file should be writable. It will be created if it doesn't exist.
 status_file: "/config/wolnut_state.json" 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,7 +36,7 @@ nut:
   ups: "ups@localhost"
 
 # The directory for the status file should be writable. It will be created if it doesn't exist.
-status_file: "/config/wolnut_state.json" 
+status_file: "/config/wolnut_state.json"
 
 clients:
   - name: "my-pc"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,9 +25,6 @@ def full_config_dict():
         "status_file": "/data/status.json",
         "nut": {
             "ups": "myups@nut-server",
-            "port": 1234,
-            "username": "monuser",
-            "password": "monpassword",
         },
         "wake_on": {
             "restore_delay_sec": 60,
@@ -82,7 +79,6 @@ def test_load_config_full(mocker, full_config_dict):
     assert cfg.poll_interval == 5
     assert cfg.status_file == "/data/status.json"
     assert cfg.nut.ups == "myups@nut-server"
-    assert cfg.nut.username == "monuser"
     assert cfg.wake_on.restore_delay_sec == 60
     assert cfg.wake_on.min_battery_percent == 50
     assert len(cfg.clients) == 2

--- a/wolnut/config.py
+++ b/wolnut/config.py
@@ -17,10 +17,6 @@ DEFAULT_LOG_LEVEL = "INFO"
 @dataclass
 class NutConfig:
     ups: str
-    port: int = 3493
-    timeout: int = 5
-    username: str | None = None
-    password: str | None = None
 
 
 @dataclass

--- a/wolnut/monitor.py
+++ b/wolnut/monitor.py
@@ -1,25 +1,16 @@
 import subprocess
 import logging
 import platform
-from typing import Optional
 
 logger = logging.getLogger("wolnut")
 
 
-def get_ups_status(
-    ups_name: str, username: Optional[str] = None, password: Optional[str] = None
-) -> dict:
-    env = None
-
-    if username and password:
-        env = {**subprocess.os.environ, "USERNAME": username, "PASSWORD": password}
-
+def get_ups_status(ups_name: str) -> dict:
     try:
         result = subprocess.run(
             ["upsc", ups_name],
             capture_output=True,
             text=True,
-            env=env,
             timeout=5,
             check=False,
         )


### PR DESCRIPTION
This PR aligns documentation with current implementation.

- Remove obsolete nut.hostname entry
- Document nut.ups as ups@hostname
- Update quickstart config example accordingly
- Remove unused configurations

The error was introduced in this [commit](https://github.com/hardwarehaven/wolnut/commit/87760773806b8e2e638351094fdfd3ca78b027fb#diff-0e381509c2d5a64119ef45b38ee49cb47b89c834c674411e2f4bbb68892ba378) where hostname was removed but documentation was added mentionning it.